### PR TITLE
Add “routing“ and blank settings page

### DIFF
--- a/host/SubscriptionHost/SubscriptionHost.tsx
+++ b/host/SubscriptionHost/SubscriptionHost.tsx
@@ -9,48 +9,64 @@ import {
 import {ModalContainer} from '../containers/ModalContainer';
 import {HostProps} from '../types';
 import {SubscriptionExtension} from './SubscriptionExtension';
+import {SubscriptionSettings} from './SubscriptionSettings';
+
+const SETTINGS_PATH = '/settings';
 
 export function SubscriptionHost(props: HostProps) {
   const [open, setOpen] = useState(false);
+  const {pathname} = window.location;
+  const [settingsActive, setSettingsActive] = useState(
+    window.location.pathname === SETTINGS_PATH
+  );
 
   const navigationMarkup = (
-    <Navigation location="/">
+    <Navigation location={pathname}>
       <Navigation.Section
         fill
         items={[
           {
-            url: '',
+            url: '/',
+            onClick: () => setSettingsActive(false),
             label: 'Subscription extension',
             icon: ProductsMajorTwotone,
-            selected: true,
+            selected: !settingsActive,
           },
         ]}
       />
       <Navigation.Section
         items={[
           {
-            url: '/settings',
+            url: SETTINGS_PATH,
+            onClick: () => setSettingsActive(true),
             label: 'Settings',
             icon: SettingsMajorMonotone,
+            selected: settingsActive,
           },
         ]}
       />
     </Navigation>
   );
 
+  const settingsMarkup = <SubscriptionSettings />;
+
+  const extensionMarkup = (
+    <SubscriptionExtension>
+      <Button onClick={() => setOpen(true)}>Create subscription plan</Button>
+      <ModalContainer
+        app={{name: 'App name', appId: 'app-id'}}
+        open={open}
+        defaultTitle="Default title"
+        onClose={() => setOpen(false)}
+        extensionPoint={ExtensionPoint.SubscriptionManagement}
+        {...props}
+      />
+    </SubscriptionExtension>
+  );
+
   return (
     <Frame navigation={navigationMarkup} topBar={<TopBar />}>
-      <SubscriptionExtension>
-        <Button onClick={() => setOpen(true)}>Create subscription plan</Button>
-        <ModalContainer
-          app={{name: 'App name', appId: 'app-id'}}
-          open={open}
-          defaultTitle="Default title"
-          onClose={() => setOpen(false)}
-          extensionPoint={ExtensionPoint.SubscriptionManagement}
-          {...props}
-        />
-      </SubscriptionExtension>
+      {settingsActive ? settingsMarkup : extensionMarkup}
     </Frame>
   );
 }

--- a/host/SubscriptionHost/SubscriptionSettings.tsx
+++ b/host/SubscriptionHost/SubscriptionSettings.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  SkeletonBodyText,
+  Page,
+  Layout,
+  Card,
+} from '@shopify/polaris';
+
+export function SubscriptionSettings() {
+  return (
+    <Page title="Settings">
+      <Layout>
+        <Layout.Section>
+          <Card sectioned>
+            <SkeletonBodyText />
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}


### PR DESCRIPTION
Part of https://github.com/Shopify/app-extension-libs/issues/337

Adds a rudimentary "router" and a blank settings page:

![Screen Shot 2020-05-15 at 2 23 39 PM](https://user-images.githubusercontent.com/3248903/82083463-c2d2d500-96b7-11ea-88ab-09c40323a19c.png)
