### PR TITLE
Fix webpack config

### DIFF
--- a/host/SubscriptionHost/types/index.ts
+++ b/host/SubscriptionHost/types/index.ts
@@ -1,3 +1,3 @@
 export * from './selling-plan-group';
-export {Settings, SubscriptionData, SubscriptionManagementActions} from './settings';
+export * from './settings';
 export {PathFn} from './path-fn';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,7 @@ module.exports = {
               '@babel/plugin-proposal-optional-chaining',
               '@babel/plugin-proposal-nullish-coalescing-operator',
               ['@babel/plugin-proposal-class-properties', {loose: true}],
+              require.resolve('@shopify/web-worker/babel'),
             ],
             sourceType: 'unambiguous',
           },


### PR DESCRIPTION
This PR fixes webpack config and typescript.

## Tophat instruction:
- `yarn && yarn generate --type=SUBSCRIPTION_MANAGEMENT && yarn server`.
- Verify that webpack compiles successfully `｢wdm｣: Compiled successfully.`. 
- Verify that extension is opened as expected.