### PR TITLE
fix: remove selling plan page state

### DIFF
--- a/host/SubscriptionHost/components/SellingPlanGroup.tsx
+++ b/host/SubscriptionHost/components/SellingPlanGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   ResourceList,
   ResourceItem,
@@ -12,7 +12,6 @@ import {BasicField} from './action-field';
 import {SellingPlanModal} from './SellingPlanModal';
 import {Settings, SellingPlan} from '../types';
 import {mockSellingPlan} from '../mocks';
-import {usePageState} from '../useStorage';
 
 interface SellingPlanGroupProps {
   settings: Settings;
@@ -21,11 +20,8 @@ interface SellingPlanGroupProps {
 
 export function SellingPlanGroup(props: SellingPlanGroupProps) {
   const {settings, updateSettings} = props;
-  const [{activeSellingPlan, newSellingPlan}, setPageState] = usePageState();
-  const setActiveSellingPlan = (plan?: SellingPlan) =>
-    setPageState((state) => state.activeSellingPlan, plan);
-  const setNewSellingPlan = (plan?: SellingPlan) =>
-    setPageState((state) => state.newSellingPlan, plan);
+  const [activeSellingPlan, setActiveSellingPlan] = useState<SellingPlan | undefined>();
+  const [newSellingPlan, setNewSellingPlan] = useState<SellingPlan | undefined>();
 
   function onSave(newPlan: SellingPlan) {
     const index = settings.data!.sellingPlanGroup.sellingPlans.findIndex(

--- a/host/SubscriptionHost/useStorage.ts
+++ b/host/SubscriptionHost/useStorage.ts
@@ -42,9 +42,5 @@ export function useSettings() {
 }
 
 export function usePageState() {
-  return useStorage('SubscriptionHost::pageState', {
-    extensionOpen: false,
-    activeSellingPlan: null as SellingPlan | null,
-    newSellingPlan: null as SellingPlan | null,
-  });
+  return useStorage('SubscriptionHost::pageState', {extensionOpen: false});
 }


### PR DESCRIPTION
Removes page state of the Edit/Add selling plan so that on browser refresh their modal doesn't stay open (they'll lose unsaved work). They must click Update/Add modal primary action to save these changes.