### PR TITLE
Failures return non-0 exit code to CLI

### DIFF
--- a/scripts/generate/index.ts
+++ b/scripts/generate/index.ts
@@ -41,8 +41,12 @@ See README.md for instructions.
 
   console.log('✅ You selected:', framework);
 
-  generateSrc(extensionType, framework as Framework);
-  generateConfig(extensionType);
-
-  cleanUp();
+  try {
+    generateSrc(extensionType, framework as Framework);
+    generateConfig(extensionType);
+    cleanUp();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
 })();


### PR DESCRIPTION
Co-authored-by: Phiroze <phiroze.dennis@shopify.com>

### Overview
Part of: https://github.com/Shopify/app-extension-libs/issues/719

Currently, if there is a failure on the template initialization it is returning with a 0 exit code which means we can't detect it on the CLI side.
This PR catches any exceptions and exits with an error code of 1 so we can detect it on the CLI.

### Before
![before](https://user-images.githubusercontent.com/42751082/84701443-0329ab00-af23-11ea-9383-99e861c75b6e.png)

### After
![after](https://user-images.githubusercontent.com/42751082/84701472-0f156d00-af23-11ea-8b5b-b062a38957f8.png)
