### PR TITLE
feat: use argo-admin-react package

### DIFF
--- a/docs/Components/Badge.md
+++ b/docs/Components/Badge.md
@@ -7,7 +7,7 @@ Badges are used to inform merchants of the status of an object or of an action t
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Badge} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Badge} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const badge = root.createComponent(Badge, {
@@ -23,8 +23,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Badge} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Badge} from '@shopify/argo-admin-react';
 
 function App() {
   return <Badge message="Example message" status="success" />;
@@ -35,7 +34,7 @@ render(ExtensionPoint.MyExtension, () => <App />);
 
 ## Props API
 
-| Name    | Type                                                       | Description                                       | Required |
-| ------- | ---------------------------------------------------------- | ------------------------------------------------- | -------- |
-| message | `string`                                                   | The content to display inside the badge.          | ☑️       |
+| Name    | Type                                                       | Description                                                              | Required |
+| ------- | ---------------------------------------------------------- | ------------------------------------------------------------------------ | -------- |
+| message | `string`                                                   | The content to display inside the badge.                                 | ☑️       |
 | status  | `'success'`, `'info'`, `'attention'`, `'warning'`, `'new'` | Set the colour of the badge for the given status. Defaults to no status. |          |

--- a/docs/Components/Banner.md
+++ b/docs/Components/Banner.md
@@ -7,7 +7,7 @@ Informs merchants about important changes or persistent conditions. Use this com
 #### Vanilla
 
 ```js
-  import {ExtensionPoint, render, Banner} from '@shopify/argo-admin';
+  import {render, ExtensionPoint, Banner} from '@shopify/argo-admin';
 
   render(ExtensionPoint.MyExtension, (root) => {
     const banner = root.createComponent(Banner, {
@@ -33,8 +33,7 @@ Informs merchants about important changes or persistent conditions. Use this com
 #### React
 
 ```jsx
-import {ExtensionPoint, Banner} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Banner} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Button.md
+++ b/docs/Components/Button.md
@@ -7,7 +7,7 @@ Buttons are used primarily for actions, such as “Add”, “Close”, “Cance
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Button} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Button} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const button = root.createComponent(Button, {
@@ -25,8 +25,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Button} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Button} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Card.md
+++ b/docs/Components/Card.md
@@ -9,8 +9,7 @@ Cards are used to group similar concepts and tasks together to make Shopify easi
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Card} from '@shopify/argo-admin';
-import {} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Card} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const card = root.createComponent(Card, {});
@@ -25,8 +24,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Card} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Card} from '@shopify/argo-admin-react';
 
 function App() {
   return <Card>...</Card>;

--- a/docs/Components/CardSection.md
+++ b/docs/Components/CardSection.md
@@ -9,7 +9,7 @@ The CardSection component is ...
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, CardSection} from '@shopify/argo-admin';
+import {render, ExtensionPoint, CardSection} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const cardsection = root.createComponent(CardSection, {});
@@ -24,8 +24,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, CardSection} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, CardSection} from '@shopify/argo-admin-react';
 
 function App() {
   return <CardSection>...</CardSection>;

--- a/docs/Components/Checkbox.md
+++ b/docs/Components/Checkbox.md
@@ -7,7 +7,7 @@ Checkboxes are most commonly used to give merchants a way to make a range of sel
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Checkbox} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Checkbox} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const checkbox = root.createComponent(Checkbox, {
@@ -25,8 +25,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Checkbox} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Checkbox} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Clickable.md
+++ b/docs/Components/Clickable.md
@@ -7,7 +7,7 @@ Clickable allows you to add an onClick callback function to any component.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Clickable, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Clickable, Text} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const clickable = root.createComponent(Clickable, {
@@ -28,8 +28,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Clickable} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Clickable} from '@shopify/argo-admin-react';
 
 function App() {
   return <Clickable onClick={() => console.log('I’ve been clicked!')}>I can be clicked</Clickable>;

--- a/docs/Components/Icon.md
+++ b/docs/Components/Icon.md
@@ -7,7 +7,7 @@ Icons are used to visually communicate available actions. They can act as wayfin
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Icon} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Icon} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const icon = root.createComponent(Icon, {
@@ -25,8 +25,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Icon} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Icon} from '@shopify/argo-admin-react';
 
 function App() {
   return <Icon source="cancelSmallMinor" color="blue" />;

--- a/docs/Components/Link.md
+++ b/docs/Components/Link.md
@@ -7,7 +7,7 @@ Links take users to another place, and usually appear within or directly followi
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Link} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Link} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const link = root.createComponent(Link, {
@@ -31,8 +31,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Link} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Link} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Modal.md
+++ b/docs/Components/Modal.md
@@ -9,7 +9,7 @@ The Modal component is ...
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Modal} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Modal} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const modal = root.createComponent(Modal, {});
@@ -24,8 +24,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Modal} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Modal} from '@shopify/argo-admin-react';
 
 function App() {
   return <Modal>...</Modal>;

--- a/docs/Components/Page.md
+++ b/docs/Components/Page.md
@@ -9,7 +9,7 @@ The Page component is ...
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Page} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Page} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const page = root.createComponent(Page, {});
@@ -24,8 +24,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Page} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Page} from '@shopify/argo-admin-react';
 
 function App() {
   return <Page>...</Page>;

--- a/docs/Components/Radio.md
+++ b/docs/Components/Radio.md
@@ -7,7 +7,7 @@ Use radio buttons to present each item in a list of options where merchants must
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, RadioButton} from '@shopify/argo-admin';
+import {render, ExtensionPoint, RadioButton} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const radio1 = root.createComponent(RadioButton, {
@@ -36,8 +36,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, RadioButton} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, RadioButton} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/ResourceItem.md
+++ b/docs/Components/ResourceItem.md
@@ -9,7 +9,7 @@ A ResourceItem should be rendered within a [ResourceList](./ResourceList.md).
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, ResourceList, ResourceItem} from '@shopify/argo-admin';
+import {render, ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const resourceitem1 = root.createComponent(ResourceItem, {
@@ -36,8 +36,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/ResourceList.md
+++ b/docs/Components/ResourceList.md
@@ -10,7 +10,7 @@ A resource list should contain [ResourceItem](./ResourceItem.md) components.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, ResourceList, ResourceItem} from '@shopify/argo-admin';
+import {render, ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const resourceitem1 = root.createComponent(ResourceItem, {
@@ -44,8 +44,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, ResourceList, ResourceItem} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Select.md
+++ b/docs/Components/Select.md
@@ -7,7 +7,7 @@ Select lets merchants choose one option from an options menu. Consider select wh
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Select} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Select} from '@shopify/argo-admin';
 
 const options = [
   {
@@ -42,8 +42,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Select} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Select} from '@shopify/argo-admin-react';
 
 const options = [
   {

--- a/docs/Components/Spinner.md
+++ b/docs/Components/Spinner.md
@@ -7,7 +7,7 @@ Spinners are used to notify merchants that their action is being processed.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Spinner} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Spinner} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const spinner = root.createComponent(Spinner);
@@ -24,8 +24,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Spinner} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Spinner} from '@shopify/argo-admin-react';
 
 function App() {
   return <Spinner />;

--- a/docs/Components/Stack.md
+++ b/docs/Components/Stack.md
@@ -9,7 +9,7 @@ Use [StackItem](./StackItem) to group multiple elements inside a Stack together.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Stack, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Stack, Text} from '@shopify/argo-admin';
 
 function buildInlineText(root) {
   const text = root.createComponent(Text);
@@ -53,8 +53,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Stack, Text} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Stack, Text} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/StackItem.md
+++ b/docs/Components/StackItem.md
@@ -9,7 +9,7 @@ Use the fill prop on a single stack item component to make it fill the rest of t
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Stack, StackItem, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Stack, StackItem, Text} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const stack = root.createComponent(Stack);
@@ -39,8 +39,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Stack, StackItem, Text} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Stack, StackItem, Text} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Text.md
+++ b/docs/Components/Text.md
@@ -8,7 +8,7 @@ You can also render simple text without styling.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Text} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const formattedText = root.createComponent(Text, {
@@ -31,8 +31,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Text} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Text} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/TextField.md
+++ b/docs/Components/TextField.md
@@ -8,7 +8,7 @@ It has a range of options and supports several text formats including numbers.
 #### Vanilla
 
 ```js
-  import {ExtensionPoint, render, TextField} from '@shopify/argo-admin';
+  import {render, ExtensionPoint, TextField} from '@shopify/argo-admin';
 
   render(ExtensionPoint.MyExtension, (root) => {
     const textfield = root.createComponent(TextField, {
@@ -35,8 +35,7 @@ It has a range of options and supports several text formats including numbers.
 #### React
 
 ```jsx
-import {ExtensionPoint, TextField} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, TextField} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Components/Thumbnail.md
+++ b/docs/Components/Thumbnail.md
@@ -7,7 +7,7 @@ Use thumbnails as a visual anchor and identifier for an object. They should be u
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Thumbnail} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Thumbnail} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root) => {
   const thumbnail = root.createComponent(Thumbnail, {
@@ -25,8 +25,7 @@ render(ExtensionPoint.MyExtension, (root) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Thumbnail} from '@shopify/argo-admin';
-import {render} from '@shopify/argo-admin/react';
+import {render, ExtensionPoint, Thumbnail} from '@shopify/argo-admin-react';
 
 function App() {
   return (

--- a/docs/Utilities/Container.md
+++ b/docs/Utilities/Container.md
@@ -1,31 +1,20 @@
 # Container
 
-Each extension point should provide a container API, allowing the extension to customize its container UI and communicate the end of its lifecycle.
+Each extension point is provided a container API which provides additional methods the extension can use to communicate with Shopify Admin.
 
 ## Subscription Management
 
-Subscription Management extensions are rendered in a modal, so their container has primary and secondary actions.
-
-| Name               | Type              | Description                                                                                                                            | Required |
-| ------------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| close              | `function`        | Closes the container and the extension                                                                                                 |          |
-| done               | `function`        | Notify Shopify Admin that the extension workflow is complete and data has been updated, so Admin should refresh related UI on the page |          |
-| setPrimaryAction   | `(ContainerAction) => void` | Sets the primary action content and callback when the action is clicked                                                                |          |
-| setSecondaryAction | `(ContainerAction) => void` | Sets the secondary action content and callback when the action is clicked                                                              |          |
-
-### ContainerAction
-
-| Name     | Type       | Description                          | Required |
-| -------- | ---------- | ------------------------------------ | -------- |
-| content  | `string`   | Label for the action.                | ☑️       |
-| onAction | `function` | Callback when the action is clicked. | ☑️       |
-
-### Examples
+| Name               | Type       | Description                                                                            | Required |
+| ------------------ | ---------- | -------------------------------------------------------------------------------------- | -------- |
+| close              | `function` | Closes the container and the extension                                                 |          |
+| done               | `function` | Notify Shopify Admin that the extension workflow is complete and data has been updated |          |
+| setPrimaryAction   | `function` | Sets the primary action content and callback when the action is clicked                |          |
+| setSecondaryAction | `function` | Sets the secondary action content and callback when the action is clicked              |          |
 
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Button} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Button} from '@shopify/argo-admin';
 
 render(ExtensionPoint.SubscriptionManagementCreate, (root, api) => {
   const {
@@ -61,8 +50,7 @@ render(ExtensionPoint.SubscriptionManagementCreate, (root, api) => {
 #### React
 
 ```js
-import {ExtensionPoint, Text} from '@shopify/argo-admin';
-import {render, useContainer} from '@shopify/argo-admin/react';
+import {render, useContainer, ExtensionPoint, Text} from '@shopify/argo-admin-react';
 
 function App() {
   const container = useContainer();

--- a/docs/Utilities/Layout.md
+++ b/docs/Utilities/Layout.md
@@ -7,7 +7,7 @@ You can use the Layout utility to adjust your content based on the user's screen
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Text} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root, api) => {
   const {layout} = api;
@@ -27,8 +27,7 @@ render(ExtensionPoint.MyExtension, (root, api) => {
 #### React
 
 ```js
-import {ExtensionPoint, Text} from '@shopify/argo-admin';
-import {render, useLayout} from '@shopify/argo-admin/react';
+import {render, useLayout, ExtensionPoint, Text} from '@shopify/argo-admin';
 
 function App() {
   const layout = useLayout();

--- a/docs/Utilities/Locale.md
+++ b/docs/Utilities/Locale.md
@@ -7,7 +7,7 @@ Access the merchant’s current locale (in [IETF format](https://en.wikipedia.or
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Text} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Text} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root, api) => {
   const {locale} = api;
@@ -30,8 +30,7 @@ render(ExtensionPoint.MyExtension, (root, api) => {
 #### React
 
 ```js
-import {ExtensionPoint, Text} from '@shopify/argo-admin';
-import {render, useLocale} from '@shopify/argo-admin/react';
+import {render, useLocale, ExtensionPoint, Text} from '@shopify/argo-admin-react';
 
 function App() {
   const locale = useLocale();

--- a/docs/Utilities/SessionToken.md
+++ b/docs/Utilities/SessionToken.md
@@ -7,7 +7,7 @@ Get a fresh session token for communication with your app's backend.
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, TextField} from '@shopify/argo-admin';
+import {render, ExtensionPoint, TextField} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root, api) => {
   const {sessionToken} = api;
@@ -31,8 +31,7 @@ render(ExtensionPoint.MyExtension, (root, api) => {
 #### React
 
 ```js
-import {ExtensionPoint, TextField} from '@shopify/argo-admin';
-import {render, useSessionToken} from '@shopify/argo-admin/react';
+import {render, useSessionToken, ExtensionPoint, TextField} from '@shopify/argo-admin-react';
 
 function App() {
   const {getSessionToken} = useSessionToken();

--- a/docs/Utilities/Toast.md
+++ b/docs/Utilities/Toast.md
@@ -7,7 +7,7 @@ The toast component is a non-disruptive message that appears at the bottom of th
 #### Vanilla
 
 ```js
-import {ExtensionPoint, render, Button} from '@shopify/argo-admin';
+import {render, ExtensionPoint, Button} from '@shopify/argo-admin';
 
 render(ExtensionPoint.MyExtension, (root, api) => {
   const {toast} = api;
@@ -30,8 +30,7 @@ render(ExtensionPoint.MyExtension, (root, api) => {
 #### React
 
 ```jsx
-import {ExtensionPoint, Button} from '@shopify/argo-admin';
-import {render, useToast} from '@shopify/argo-admin/react';
+import {render, useToast, ExtensionPoint, Button} from '@shopify/argo-admin-react';
 
 function App() {
   const {show: showToast} = useToast();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@shopify/argo-admin": "latest",
+    "@shopify/argo-admin-react": "latest",
     "react": "^16.13.0"
   }
 }

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.js.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.js.template
@@ -1,17 +1,15 @@
 import React, {useState, useEffect} from 'react';
 import {
+  Checkbox,
   ExtensionPoint,
   TextField,
   Text,
   Stack,
-  Checkbox,
-} from '@shopify/argo-admin';
-import {
   render,
   useData,
   useContainer,
   useSessionToken,
-} from '@shopify/argo-admin/react';
+} from '@shopify/argo-admin-react';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 function Add() {

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.tsx.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.tsx.template
@@ -1,17 +1,15 @@
 import React, {useState, useEffect} from 'react';
 import {
+  Checkbox,
   ExtensionPoint,
   TextField,
   Text,
   Stack,
-  Checkbox,
-} from '@shopify/argo-admin';
-import {
   render,
   useData,
   useContainer,
   useSessionToken,
-} from '@shopify/argo-admin/react';
+} from '@shopify/argo-admin-react';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 function Add() {

--- a/scripts/generate/update-package-json.ts
+++ b/scripts/generate/update-package-json.ts
@@ -3,28 +3,39 @@ import path from 'path';
 import {promisify} from 'util';
 import {Template} from './generate-src';
 
-export function addScripts({entry, type}: {entry: string, type: string}) {
+export function addScripts({entry, type}: {entry: string; type: string}) {
   return updatePackage((npmPackage) => {
-    npmPackage.scripts['server'] = `argo-admin-cli server --entry="${entry}" --port=39351 --type=${type}`;
+    npmPackage.scripts[
+      'server'
+    ] = `argo-admin-cli server --entry="${entry}" --port=39351 --type=${type}`;
     npmPackage.scripts['build'] = `argo-admin-cli build --entry="${entry}"`;
     return npmPackage;
   });
 }
 
 export function cleanUpInitialize({template}: {template: Template}) {
-  const isTypescript = [Template.VanillaTypescript, Template.ReactTypescript].includes(template);
+  const isTypescript = [
+    Template.VanillaTypescript,
+    Template.ReactTypescript,
+  ].includes(template);
   const isReact = [Template.React, Template.ReactTypescript].includes(template);
 
   return updatePackage((npmPackage) => {
     npmPackage.scripts.generate = undefined;
     const {devDependencies} = npmPackage;
+
     npmPackage.devDependencies = {
       '@shopify/argo-admin-cli': devDependencies['@shopify/argo-admin-cli'],
       typescript: isTypescript ? devDependencies['typescript'] : undefined,
     };
-    npmPackage.dependencies.react = isReact
-      ? npmPackage.dependencies.react
-      : undefined;
+
+    if(isReact) {
+      npmPackage.dependencies['@shopify/argo-admin'] = undefined;
+    } else {
+      npmPackage.dependencies.react = undefined;
+      npmPackage.dependencies['@shopify/argo-admin-react'] = undefined;
+    }
+
     return npmPackage;
   });
 }


### PR DESCRIPTION
Related to https://github.com/Shopify/app-extension-libs/issues/789

This PR updates the docs and template to use the new argo-admin-react package

NOTE: We need to ship a stable release of argo-admin (0.4.0) before merging this PR

### Tophat

1. Update the package.json to point to the test branch of argo-admin-cli `"@shopify/argo-admin-cli": "git+https://github.com/Shopify/argo-admin-cli.git#test-argo-admin-react",`
2. Run`yarn install`
3. Verify that running `yarn generate --type=SUBSCRIPTION_MANAGEMENT` and selecting the React or React with Typescript removes `@shopify/argo-admin` dependency from the package.json
4. Verify that running `yarn generate --type=SUBSCRIPTION_MANAGEMENT` and selecting a template without React removes `@shopify/argo-admin-react` dependency from the package.json
5. Do a smoke test and verify that `yarn server` and `yarn build` works for both React and non-react templates with no errors thrown