### PR TITLE
Update templates to work with app overlay

### DIFF
--- a/docs/ExtensionPoints/SubscriptionManagement/README.md
+++ b/docs/ExtensionPoints/SubscriptionManagement/README.md
@@ -108,7 +108,6 @@ The following components are available only for Subscription Management Create a
 - [Card](../../Components/Card.md)
 - [CardSection](../../Components/CardSection.md)
 - [Modal](../../Components/Modal.md)
-- [Page](../../Components/Page.md)
 
 ## Available utilities
 

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.js.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.js.template
@@ -1,5 +1,7 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useMemo, useCallback} from 'react';
 import {
+  Button,
+  Card,
   Checkbox,
   ExtensionPoint,
   TextField,
@@ -12,6 +14,7 @@ import {
 } from '@shopify/argo-admin-react';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
+// [Shopify admin renders this mode inside a modal container]
 function Add() {
   // Information about the product and/or plan your extension is editing.
   // Your extension receives different data in each mode.
@@ -81,9 +84,10 @@ function Add() {
 }
 
 // 'Create' mode should create a new selling plan, and add the current product to it
+// [Shopify admin renders this mode inside an app overlay container]
 function Create() {
   const data = useData();
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done} = useContainer();
   const {getSessionToken} = useSessionToken();
 
   // Mock plan settings
@@ -91,53 +95,57 @@ function Create() {
   const [percentageOff, setPercentageOff] = useState('');
   const [deliveryFrequency, setDeliveryFrequency] = useState('');
 
-  useEffect(() => {
-    setPrimaryAction({
-      content: 'Create plan',
-      onAction: async () => {
-        // Get a fresh session token before every call to your app server.
-        const token = await getSessionToken();
+  const onPrimaryAction = useCallback(async () => {
+    const token = await getSessionToken();
 
-        // Here, send the form data to your app server to create the new plan.
+    // Here, send the form data to your app server to create the new plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
-        done();
-        close();
-      },
-    });
-
-    setSecondaryAction({
-      content: 'Cancel',
-      onAction: () => close(),
-    });
+    done();
+    close();
   }, [getSessionToken]);
 
+  const actions = useMemo(() => (
+    <Stack distribution="fill">
+      <Button title="Cancel" onClick={() => close()} />
+      <Stack distribution="trailing">
+        <Button title="Create plan" onClick={onPrimaryAction} primary/>
+      </Stack>
+    </Stack>
+  ), [onPrimaryAction]);
+
   return (
-    <Stack vertical>
-      <Text>
-        Create subscription plan for {`{Product id ${data.productId}}`}
-      </Text>
+    <Stack distribution="center">
+      <Stack vertical>
 
-      <TextField
-        label="Plan title"
-        value={planTitle}
-        onAfterChange={setPlanTitle}
-      />
+        <Text size="titleLarge">Create subscription plan</Text>
 
-      <Stack>
-        <TextField
-          type="number"
-          label="Delivery frequency (in weeks)"
-          value={deliveryFrequency}
-          onAfterChange={setDeliveryFrequency}
-        />
-        <TextField
-          type="number"
-          label="Percentage off (%)"
-          value={percentageOff}
-          onAfterChange={setPercentageOff}
-        />
+        <Card title={`Create subscription plan for Product id ${data.productId}`} sectioned>
+          <TextField
+            label="Plan title"
+            value={planTitle}
+            onAfterChange={setPlanTitle}
+          />
+        </Card>
+
+        <Card title="Delivery and discount" sectioned>
+          <Stack>
+            <TextField
+              type="number"
+              label="Delivery frequency (in weeks)"
+              value={deliveryFrequency}
+              onAfterChange={setDeliveryFrequency}
+            />
+            <TextField
+              type="number"
+              label="Percentage off (%)"
+              value={percentageOff}
+              onAfterChange={setPercentageOff}
+            />
+          </Stack>
+        </Card>
+
+        {actions}
+
       </Stack>
     </Stack>
   );
@@ -145,21 +153,20 @@ function Create() {
 
 // 'Remove' mode should remove the current product from a selling plan.
 // This should not delete the selling plan.
+// [Shopify admin renders this mode inside a modal container]
 function Remove() {
   const data = useData();
   const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {getSessionToken} = useSessionToken();
 
   useEffect(() => {
     setPrimaryAction({
       content: 'Remove from plan',
       onAction: async () => {
-        // Get a fresh session token before every call to your app server.
         const token = await getSessionToken();
 
         // Here, send the form data to your app server to remove the product from the plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
         done();
         close();
       },
@@ -181,62 +188,67 @@ function Remove() {
 
 // 'Edit' mode should modify an existing selling plan.
 // Changes should affect other products that have this plan applied.
+// [Shopify admin renders this mode inside an app overlay container]
 function Edit() {
   const data = useData();
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done} = useContainer();
   const {getSessionToken} = useSessionToken();
 
   const [planTitle, setPlanTitle] = useState('Current plan');
   const [percentageOff, setPercentageOff] = useState('10');
   const [deliveryFrequency, setDeliveryFrequency] = useState('1');
 
-  useEffect(() => {
-    setPrimaryAction({
-      content: 'Edit plan',
-      onAction: async () => {
-        // Get a fresh session token before every call to your app server.
-        const token = await getSessionToken();
+  const onPrimaryAction = useCallback(async () => {
+    const token = await getSessionToken();
 
-        // Here, send the form data to your app server to modify the selling plan.
+    // Here, send the form data to your app server to modify the selling plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
-        done();
-        close();
-      },
-    });
-
-    setSecondaryAction({
-      content: 'Cancel',
-      onAction: () => close(),
-    });
+    done();
+    close();
   }, [getSessionToken]);
 
+  const actions = useMemo(() => (
+    <Stack distribution="fill">
+      <Button title="Cancel" onClick={() => close()} />
+      <Stack distribution="trailing">
+        <Button title="Edit plan" onClick={onPrimaryAction} primary/>
+      </Stack>
+    </Stack>
+  ), [onPrimaryAction]);
+
   return (
-    <Stack vertical>
-      <Text>
-        Create subscription plan for {`{Product id ${data.productId}}`}
-      </Text>
+    <Stack distribution="center">
+      <Stack vertical>
 
-      <TextField
-        label="Plan title"
-        value={planTitle}
-        onAfterChange={setPlanTitle}
-      />
+        <Text size="titleLarge">Edit subscription plan</Text>
 
-      <Stack>
-        <TextField
-          type="number"
-          label="Delivery frequency (in weeks)"
-          value={deliveryFrequency}
-          onAfterChange={setDeliveryFrequency}
-        />
-        <TextField
-          type="number"
-          label="Percentage off (%)"
-          value={percentageOff}
-          onAfterChange={setPercentageOff}
-        />
+        <Card title={`Edit subscription plan for Product id ${data.productId}`} sectioned>
+          <TextField
+            label="Plan title"
+            value={planTitle}
+            onAfterChange={setPlanTitle}
+          />
+        </Card>
+
+        <Card title="Delivery and discount" sectioned>
+          <Stack>
+            <TextField
+              type="number"
+              label="Delivery frequency (in weeks)"
+              value={deliveryFrequency}
+              onAfterChange={setDeliveryFrequency}
+            />
+            <TextField
+              type="number"
+              label="Percentage off (%)"
+              value={percentageOff}
+              onAfterChange={setPercentageOff}
+            />
+          </Stack>
+        </Card>
+
+        {actions}
+
       </Stack>
     </Stack>
   );

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.tsx.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.tsx.template
@@ -1,5 +1,7 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useMemo, useCallback} from 'react';
 import {
+  Button,
+  Card,
   Checkbox,
   ExtensionPoint,
   TextField,
@@ -12,13 +14,14 @@ import {
 } from '@shopify/argo-admin-react';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
+// [Shopify admin renders this mode inside a modal container]
 function Add() {
   // Information about the product and/or plan your extension is editing.
   // Your extension receives different data in each mode.
   const data = useData<ExtensionPoint.SubscriptionManagementAdd>();
 
   // The UI your extension renders inside
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer<ExtensionPoint.SubscriptionManagementAdd>();
 
   // Session token contains information about the current user. Use it to authenticate calls
   // from your extension to your app server.
@@ -81,9 +84,10 @@ function Add() {
 }
 
 // 'Create' mode should create a new selling plan, and add the current product to it
+// [Shopify admin renders this mode inside an app overlay container]
 function Create() {
   const data = useData<ExtensionPoint.SubscriptionManagementCreate>();
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done} = useContainer<ExtensionPoint.SubscriptionManagementCreate>();
   const {getSessionToken} = useSessionToken();
 
   // Mock plan settings
@@ -91,53 +95,57 @@ function Create() {
   const [percentageOff, setPercentageOff] = useState('');
   const [deliveryFrequency, setDeliveryFrequency] = useState('');
 
-  useEffect(() => {
-    setPrimaryAction({
-      content: 'Create plan',
-      onAction: async () => {
-        // Get a fresh session token before every call to your app server.
-        const token = await getSessionToken();
+  const onPrimaryAction = useCallback(async () => {
+    const token = await getSessionToken();
 
-        // Here, send the form data to your app server to create the new plan.
+    // Here, send the form data to your app server to create the new plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
-        done();
-        close();
-      },
-    });
-
-    setSecondaryAction({
-      content: 'Cancel',
-      onAction: () => close(),
-    });
+    done();
+    close();
   }, [getSessionToken]);
 
+  const actions = useMemo(() => (
+    <Stack distribution="fill">
+      <Button title="Cancel" onClick={() => close()} />
+      <Stack distribution="trailing">
+        <Button title="Create plan" onClick={onPrimaryAction} primary/>
+      </Stack>
+    </Stack>
+  ), [onPrimaryAction]);
+
   return (
-    <Stack vertical>
-      <Text>
-        Create subscription plan for {`{Product id ${data.productId}}`}
-      </Text>
+    <Stack distribution="center">
+      <Stack vertical>
 
-      <TextField
-        label="Plan title"
-        value={planTitle}
-        onAfterChange={setPlanTitle}
-      />
+        <Text size="titleLarge">Create subscription plan</Text>
 
-      <Stack>
-        <TextField
-          type="number"
-          label="Delivery frequency (in weeks)"
-          value={deliveryFrequency}
-          onAfterChange={setDeliveryFrequency}
-        />
-        <TextField
-          type="number"
-          label="Percentage off (%)"
-          value={percentageOff}
-          onAfterChange={setPercentageOff}
-        />
+        <Card title={`Create subscription plan for Product id ${data.productId}`} sectioned>
+          <TextField
+            label="Plan title"
+            value={planTitle}
+            onAfterChange={setPlanTitle}
+          />
+        </Card>
+
+        <Card title="Delivery and discount" sectioned>
+          <Stack>
+            <TextField
+              type="number"
+              label="Delivery frequency (in weeks)"
+              value={deliveryFrequency}
+              onAfterChange={setDeliveryFrequency}
+            />
+            <TextField
+              type="number"
+              label="Percentage off (%)"
+              value={percentageOff}
+              onAfterChange={setPercentageOff}
+            />
+          </Stack>
+        </Card>
+
+        {actions}
+
       </Stack>
     </Stack>
   );
@@ -145,22 +153,22 @@ function Create() {
 
 // 'Remove' mode should remove the current product from a selling plan.
 // This should not delete the selling plan.
+// [Shopify admin renders this mode inside a modal container]
 function Remove() {
   const data = useData<ExtensionPoint.SubscriptionManagementRemove>();
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer<
+    ExtensionPoint.SubscriptionManagementRemove
+  >();
   const {getSessionToken} = useSessionToken();
 
   useEffect(() => {
     setPrimaryAction({
       content: 'Remove from plan',
       onAction: async () => {
-        // Get a fresh session token before every call to your app server.
         const token = await getSessionToken();
 
         // Here, send the form data to your app server to remove the product from the plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
         done();
         close();
       },
@@ -182,6 +190,7 @@ function Remove() {
 
 // 'Edit' mode should modify an existing selling plan.
 // Changes should affect other products that have this plan applied.
+// [Shopify admin renders this mode inside an app overlay container]
 function Edit() {
   const data = useData<ExtensionPoint.SubscriptionManagementEdit>();
   const [planTitle, setPlanTitle] = useState('Current plan');
@@ -189,53 +198,59 @@ function Edit() {
 
   const [percentageOff, setPercentageOff] = useState('10');
   const [deliveryFrequency, setDeliveryFrequency] = useState('1');
-  const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const {close, done} = useContainer<ExtensionPoint.SubscriptionManagementEdit>();
 
-  useEffect(() => {
-    setPrimaryAction({
-      content: 'Edit plan',
-      onAction: async () => {
-        // Get a fresh session token before every call to your app server.
-        const token = await getSessionToken();
+  const onPrimaryAction = useCallback(async () => {
+    const token = await getSessionToken();
 
-        // Here, send the form data to your app server to modify the selling plan.
+    // Here, send the form data to your app server to modify the selling plan.
 
-        // Upon completion, call done() to trigger a reload of the resource page, and close() to
-        // terminate the extension.
-        done();
-        close();
-      },
-    });
-
-    setSecondaryAction({
-      content: 'Cancel',
-      onAction: () => close(),
-    });
+    done();
+    close();
   }, [getSessionToken]);
 
+  const actions = useMemo(() => (
+    <Stack distribution="fill">
+      <Button title="Cancel" onClick={() => close()} />
+      <Stack distribution="trailing">
+        <Button title="Edit plan" onClick={onPrimaryAction} primary/>
+      </Stack>
+    </Stack>
+  ), [onPrimaryAction]);
+
   return (
-    <Stack vertical>
-      <Text>Edit subscription plan for {`{Product id ${data.productId}}`}</Text>
+    <Stack distribution="center">
+      <Stack vertical>
 
-      <TextField
-        label="Plan title"
-        value={planTitle}
-        onAfterChange={setPlanTitle}
-      />
+        <Text size="titleLarge">Edit subscription plan</Text>
 
-      <Stack>
-        <TextField
-          type="number"
-          label="Delivery frequency (in weeks)"
-          value={deliveryFrequency}
-          onAfterChange={setDeliveryFrequency}
-        />
-        <TextField
-          type="number"
-          label="Percentage off (%)"
-          value={percentageOff}
-          onAfterChange={setPercentageOff}
-        />
+        <Card title={`Edit subscription plan for Product id ${data.productId}`} sectioned>
+          <TextField
+            label="Plan title"
+            value={planTitle}
+            onAfterChange={setPlanTitle}
+          />
+        </Card>
+
+        <Card title="Delivery and discount" sectioned>
+          <Stack>
+            <TextField
+              type="number"
+              label="Delivery frequency (in weeks)"
+              value={deliveryFrequency}
+              onAfterChange={setDeliveryFrequency}
+            />
+            <TextField
+              type="number"
+              label="Percentage off (%)"
+              value={percentageOff}
+              onAfterChange={setPercentageOff}
+            />
+          </Stack>
+        </Card>
+
+        {actions}
+
       </Stack>
     </Stack>
   );

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.js.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.js.template
@@ -3,11 +3,15 @@ import {
   TextField,
   Text,
   Stack,
+  Button,
+  Card,
   Checkbox,
   render,
 } from '@shopify/argo-admin';
+import React from 'react';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
+// [Shopify admin renders this mode inside a modal container]
 function Add(root, api) {
   // Information about the product and/or plan your extension is editing.
   // Your extension receives different data in each mode.
@@ -76,41 +80,44 @@ function Add(root, api) {
 }
 
 // 'Create' mode should create a new selling plan, and add the current product to it
+// [Shopify admin renders this mode inside an app overlay container]
 function Create(root, api) {
   const data = api.data;
   const sessionToken = api.sessionToken;
-  const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+  const {close, done} = api.container;
 
-  setPrimaryAction({
-    content: 'Create plan',
-    onAction: async () => {
-      // Get a fresh session token before every call to your app server.
+  const primaryButton = root.createComponent(Button, {
+    title: 'Create plan',
+    primary: true,
+    onClick: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to create the new plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
     },
   });
-
-  setSecondaryAction({
-    content: 'Cancel',
-    onAction: () => close(),
+  const secondaryButton = root.createComponent(Button, {
+    title: 'Cancel',
+    onClick: () => close(),
   });
 
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  root.appendChild(rootStack);
+  const containerStack = root.createComponent(Stack, {distribution: 'center'});
+  root.appendChild(containerStack);
 
-  const textElement = root.createComponent(Text);
-  textElement.appendChild(
-    root.createText(
-      `Create subscription plan for {Product id ${data.productId}}`
-    )
-  );
+  const rootStack = root.createComponent(Stack, {vertical: true});
+  containerStack.appendChild(rootStack);
+
+  const textElement = root.createComponent(Text, {size: 'titleLarge'});
+  textElement.appendChild(root.createText('Create subscription plan'));
   rootStack.appendChild(textElement);
+
+  const planTitleCard = root.createComponent(Card, {
+    sectioned: true,
+    title: `Create subscription plan for Product id ${data.productId}`,
+  });
+  rootStack.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -121,10 +128,16 @@ function Create(root, api) {
       });
     },
   });
-  rootStack.appendChild(planTitleField);
+  planTitleCard.appendChild(planTitleField);
+
+  const planDetailsCard = root.createComponent(Card, {
+    sectioned: true,
+    title: 'Delivery and discount',
+  });
+  rootStack.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
-  rootStack.appendChild(stack);
+  planDetailsCard.appendChild(stack);
 
   const deliveryFrequencyField = root.createComponent(TextField, {
     type: 'number',
@@ -150,11 +163,22 @@ function Create(root, api) {
   });
   stack.appendChild(percentageOffField);
 
+  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
+  rootStack.appendChild(actionsElement);
+  actionsElement.appendChild(secondaryButton);
+
+  const primaryButtonStack = root.createComponent(Stack, {
+    distribution: 'trailing',
+  });
+  actionsElement.appendChild(primaryButtonStack);
+  primaryButtonStack.appendChild(primaryButton);
+
   root.mount();
 }
 
 // 'Remove' mode should remove the current product from a selling plan.
 // This should not delete the selling plan.
+// [Shopify admin renders this mode inside a modal container]
 function Remove(root, api) {
   const data = api.data;
   const sessionToken = api.sessionToken;
@@ -163,13 +187,10 @@ function Remove(root, api) {
   setPrimaryAction({
     content: 'Remove from plan',
     onAction: async () => {
-      // Get a fresh session token before every call to your app server.
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to remove the product from the plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
     },
@@ -193,39 +214,44 @@ function Remove(root, api) {
 
 // 'Edit' mode should modify an existing selling plan.
 // Changes should affect other products that have this plan applied.
+// [Shopify admin renders this mode inside an app overlay container]
 function Edit(root, api) {
   const data = api.data;
   const sessionToken = api.sessionToken;
-  const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+  const {close, done} = api.container;
 
-  setPrimaryAction({
-    content: 'Edit plan',
-    onAction: async () => {
-      // Get a fresh session token before every call to your app server.
+  const primaryButton = root.createComponent(Button, {
+    title: 'Edit plan',
+    primary: true,
+    onClick: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to modify the selling plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
-    },
+    }
+  });
+  const secondaryButton = root.createComponent(Button, {
+    title: 'Cancel',
+    onClick: () => close(),
   });
 
-  setSecondaryAction({
-    content: 'Cancel',
-    onAction: () => close(),
-  });
+  const containerStack = root.createComponent(Stack, {distribution: 'center'});
+  root.appendChild(containerStack);
 
   const rootStack = root.createComponent(Stack, {vertical: true});
-  root.appendChild(rootStack);
+  containerStack.appendChild(rootStack);
 
-  const textElement = root.createComponent(Text);
-  textElement.appendChild(
-    root.createText(`Edit subscription plan for {Product id ${data.productId}}`)
-  );
+  const textElement = root.createComponent(Text, {size: 'titleLarge'});
+  textElement.appendChild(root.createText('Edit subscription plan'));
   rootStack.appendChild(textElement);
+
+  const planTitleCard = root.createComponent(Card, {
+    sectioned: true,
+    title: `Edit subscription plan for Product id ${data.productId}`,
+  });
+  rootStack.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -236,10 +262,16 @@ function Edit(root, api) {
       });
     },
   });
-  rootStack.appendChild(planTitleField);
+  planTitleCard.appendChild(planTitleField);
+
+  const planDetailsCard = root.createComponent(Card, {
+    sectioned: true,
+    title: 'Delivery and discount',
+  });
+  rootStack.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
-  rootStack.appendChild(stack);
+  planDetailsCard.appendChild(stack);
 
   const deliveryFrequencyField = root.createComponent(TextField, {
     type: 'number',
@@ -264,6 +296,16 @@ function Edit(root, api) {
     },
   });
   stack.appendChild(percentageOffField);
+
+  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
+  rootStack.appendChild(actionsElement);
+  actionsElement.appendChild(secondaryButton);
+
+  const primaryButtonStack = root.createComponent(Stack, {
+    distribution: 'trailing',
+  });
+  actionsElement.appendChild(primaryButtonStack);
+  primaryButtonStack.appendChild(primaryButton);
 
   root.mount();
 }

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.ts.template
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.ts.template
@@ -5,10 +5,13 @@ import {
   TextField,
   Text,
   Stack,
+  Button,
+  Card,
   Checkbox,
 } from '@shopify/argo-admin';
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
+// [Shopify admin renders this mode inside a modal container]
 const Add: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementAdd] = (
   root,
   api
@@ -81,44 +84,47 @@ const Add: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementAdd] = (
 };
 
 // 'Create' mode should create a new selling plan, and add the current product to it
+// [Shopify admin renders this mode inside an app overlay container]
 const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate] = (
   root,
   api
 ) => {
   const data = api.data;
   const sessionToken = api.sessionToken;
-  const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+  const {close, done} = api.container;
 
-  setPrimaryAction({
-    content: 'Create plan',
-    onAction: async () => {
-      // Get a fresh session token before every call to your app server.
+  const primaryButton = root.createComponent(Button, {
+    title: 'Create plan',
+    primary: true,
+    onClick: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to create the new plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
     },
   });
-
-  setSecondaryAction({
-    content: 'Cancel',
-    onAction: () => close(),
+  const secondaryButton = root.createComponent(Button, {
+    title: 'Cancel',
+    onClick: () => close(),
   });
 
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  root.appendChild(rootStack);
+  const containerStack = root.createComponent(Stack, {distribution: 'center'});
+  root.appendChild(containerStack);
 
-  const textElement = root.createComponent(Text);
-  textElement.appendChild(
-    root.createText(
-      `Create subscription plan for {Product id ${data.productId}}`
-    )
-  );
+  const rootStack = root.createComponent(Stack, {vertical: true});
+  containerStack.appendChild(rootStack);
+
+  const textElement = root.createComponent(Text, {size: 'titleLarge'});
+  textElement.appendChild(root.createText('Create subscription plan'));
   rootStack.appendChild(textElement);
+
+  const planTitleCard = root.createComponent(Card, {
+    sectioned: true,
+    title: `Create subscription plan for Product id ${data.productId}`,
+  });
+  rootStack.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -129,10 +135,16 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
       });
     },
   });
-  rootStack.appendChild(planTitleField);
+  planTitleCard.appendChild(planTitleField);
+
+  const planDetailsCard = root.createComponent(Card, {
+    sectioned: true,
+    title: 'Delivery and discount',
+  });
+  rootStack.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
-  rootStack.appendChild(stack);
+  planDetailsCard.appendChild(stack);
 
   const deliveryFrequencyField = root.createComponent(TextField, {
     type: 'number',
@@ -158,11 +170,22 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
   });
   stack.appendChild(percentageOffField);
 
+  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
+  rootStack.appendChild(actionsElement);
+  actionsElement.appendChild(secondaryButton);
+
+  const primaryButtonStack = root.createComponent(Stack, {
+    distribution: 'trailing',
+  });
+  actionsElement.appendChild(primaryButtonStack);
+  primaryButtonStack.appendChild(primaryButton);
+
   root.mount();
 };
 
 // 'Remove' mode should remove the current product from a selling plan.
 // This should not delete the selling plan.
+// [Shopify admin renders this mode inside a modal container]
 const Remove: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementRemove] = (
   root,
   api
@@ -174,13 +197,10 @@ const Remove: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementRemove
   setPrimaryAction({
     content: 'Remove plan',
     onAction: async () => {
-      // Get a fresh session token before every call to your app server.
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to remove the product from the plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
     },
@@ -204,42 +224,47 @@ const Remove: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementRemove
 
 // 'Edit' mode should modify an existing selling plan.
 // Changes should affect other products that have this plan applied.
+// [Shopify admin renders this mode inside an app overlay container]
 const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = (
   root,
   api
 ) => {
   const data = api.data;
   const sessionToken = api.sessionToken;
-  const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+  const {close, done} = api.container;
 
-  setPrimaryAction({
-    content: 'Edit plan',
-    onAction: async () => {
-      // Get a fresh session token before every call to your app server.
+  const primaryButton = root.createComponent(Button, {
+    title: 'Edit plan',
+    primary: true,
+    onClick: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to modify the selling plan.
 
-      // Upon completion, call done() to trigger a reload of the resource page, and close() to
-      // terminate the extension.
       done();
       close();
-    },
+    }
+  });
+  const secondaryButton = root.createComponent(Button, {
+    title: 'Cancel',
+    onClick: () => close(),
   });
 
-  setSecondaryAction({
-    content: 'Cancel',
-    onAction: () => close(),
-  });
+  const containerStack = root.createComponent(Stack, {distribution: 'center'});
+  root.appendChild(containerStack);
 
   const rootStack = root.createComponent(Stack, {vertical: true});
-  root.appendChild(rootStack);
+  containerStack.appendChild(rootStack);
 
-  const textElement = root.createComponent(Text);
-  textElement.appendChild(
-    root.createText(`Edit subscription plan for {Product id ${data.productId}}`)
-  );
+  const textElement = root.createComponent(Text, {size: 'titleLarge'});
+  textElement.appendChild(root.createText('Edit subscription plan'));
   rootStack.appendChild(textElement);
+
+  const planTitleCard = root.createComponent(Card, {
+    sectioned: true,
+    title: `Edit subscription plan for Product id ${data.productId}`,
+  });
+  rootStack.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -250,10 +275,16 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
       });
     },
   });
-  rootStack.appendChild(planTitleField);
+  planTitleCard.appendChild(planTitleField);
+
+  const planDetailsCard = root.createComponent(Card, {
+    sectioned: true,
+    title: 'Delivery and discount',
+  });
+  rootStack.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
-  rootStack.appendChild(stack);
+  planDetailsCard.appendChild(stack);
 
   const deliveryFrequencyField = root.createComponent(TextField, {
     type: 'number',
@@ -278,6 +309,16 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
     },
   });
   stack.appendChild(percentageOffField);
+
+  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
+  rootStack.appendChild(actionsElement);
+  actionsElement.appendChild(secondaryButton);
+
+  const primaryButtonStack = root.createComponent(Stack, {
+    distribution: 'trailing',
+  });
+  actionsElement.appendChild(primaryButtonStack);
+  primaryButtonStack.appendChild(primaryButton);
 
   root.mount();
 };


### PR DESCRIPTION
Closes https://github.com/Shopify/app-extension-libs/issues/814

This PR updates Argo extension templates for subscriptions to match the behaviour in admins (web, mobile, POS). Extension for modes **Add** and **Remove** are shown inside a modal container, **Create** and **Edit** are shown inside an app overlay (formerly app chrome). The app overlay also supports the `Card` component, so it's added to the templates as a demo.

#### Add, Remove in modal container (web)
<img width="1118" alt="Screen Shot 2020-08-20 at 11 43 05 AM" src="https://user-images.githubusercontent.com/2709526/90795867-97760c80-e2dc-11ea-8cb6-27c96e99860d.png">
<img width="1117" alt="Screen Shot 2020-08-20 at 11 42 51 AM" src="https://user-images.githubusercontent.com/2709526/90795870-980ea300-e2dc-11ea-9bc0-9a98dae8e3d5.png">

#### Create, Edit in app chrome container (web)
<img width="1174" alt="Screen Shot 2020-08-27 at 1 44 22 PM" src="https://user-images.githubusercontent.com/2709526/91476815-7dec3c00-e86b-11ea-8688-ca243366547a.png">
<img width="1176" alt="Screen Shot 2020-08-27 at 1 44 34 PM" src="https://user-images.githubusercontent.com/2709526/91476831-847ab380-e86b-11ea-8532-27eff5ff24c6.png">

### How to 🎩 
Check out companion PR from the [Shopify/argo-admin-cli](https://github.com/Shopify/argo-admin-cli/pull/9) repo and follow the setup instructions.

1. Please ensure scripts generated from the templates are working properly by running:
    ```sh
    yarn generate --type=SUBSCRIPTION_MANAGEMENT
    ```
    then
    ```sh
    yarn server
    ```

1. In a browser, open the simulator and test all 4 modes per script