### PR TITLE
chore: fix generate command on windows cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "generate": "ts-node -O '{\"esModuleInterop\": true}' ./scripts/generate"
+    "generate": "ts-node -O \"{\\\"esModuleInterop\\\": true}\" ./scripts/generate"
   },
   "dependencies": {
     "@shopify/argo-admin": "latest",


### PR DESCRIPTION
🎩 on Windows and Mac

1. Get PR branch

    ```bash
    git clone --single-branch --branch fix-generate-windows-cmd git@github.com:Shopify/argo-admin-template.git 

    # or
    dev clone argo-admin-template
    git checkout fix-generate-windows-cmd
    ```

1. Generate script

    ```
    npm install
    npm run generate -- --type=SUBSCRIPTION_MANAGEMENT
    ```

1. Check to see there's no errors