### PR TITLE
Add translation examples

### DIFF
--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.js
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.js
@@ -11,7 +11,20 @@ import {
   useData,
   useContainer,
   useSessionToken,
+  useLocale,
 } from '@shopify/argo-admin-react';
+
+const translations = {
+  de: {
+    hello: 'Guten Tag',
+  },
+  en: {
+    hello: 'Hello',
+  },
+  fr: {
+    hello: 'Bonjour',
+  },
+};
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 // [Shopify admin renders this mode inside a modal container]
@@ -22,6 +35,14 @@ function Add() {
 
   // The UI your extension renders inside
   const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+
+  // Information about the merchant's selected language. Use this to support multiple languages.
+  const locale = useLocale();
+
+  // Use locale to set translations with a fallback
+  const localizedStrings = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
 
   // Session token contains information about the current user. Use it to authenticate calls
   // from your extension to your app server.
@@ -59,6 +80,7 @@ function Add() {
 
   return (
     <>
+      <Text size="titleLarge">{localizedStrings.hello}!</Text>
       <Text>
         Add {`{Product id ${data.productId}}`} to an existing plan or existing
         plans
@@ -88,6 +110,11 @@ function Add() {
 function Create() {
   const data = useData();
   const {close, done} = useContainer();
+  const locale = useLocale();
+  const localizedStrings = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   // Mock plan settings
@@ -119,7 +146,9 @@ function Create() {
   return (
     <Stack distribution="center">
       <Stack vertical>
-        <Text size="titleLarge">Create subscription plan</Text>
+        <Text size="titleLarge">
+          {localizedStrings.hello}! Create subscription plan
+        </Text>
 
         <Card
           title={`Create subscription plan for Product id ${data.productId}`}
@@ -161,6 +190,11 @@ function Create() {
 function Remove() {
   const data = useData();
   const {close, done, setPrimaryAction, setSecondaryAction} = useContainer();
+  const locale = useLocale();
+  const localizedStrings = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   useEffect(() => {
@@ -183,10 +217,13 @@ function Remove() {
   }, [getSessionToken, close, done, setPrimaryAction, setSecondaryAction]);
 
   return (
-    <Text>
-      Remove {`{Product id ${data.productId}}`} from{' '}
-      {`{Plan group id ${data.sellingPlanGroupId}}`}
-    </Text>
+    <>
+      <Text size="titleLarge">{localizedStrings.hello}!</Text>
+      <Text>
+        Remove {`{Product id ${data.productId}}`} from{' '}
+        {`{Plan group id ${data.sellingPlanGroupId}}`}
+      </Text>
+    </>
   );
 }
 
@@ -196,6 +233,11 @@ function Remove() {
 function Edit() {
   const data = useData();
   const {close, done} = useContainer();
+  const locale = useLocale();
+  const localizedStrings = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   const [planTitle, setPlanTitle] = useState('Current plan');
@@ -226,7 +268,9 @@ function Edit() {
   return (
     <Stack distribution="center">
       <Stack vertical>
-        <Text size="titleLarge">Edit subscription plan</Text>
+        <Text size="titleLarge">
+          {localizedStrings.hello}! Edit subscription plan
+        </Text>
 
         <Card
           title={`Edit subscription plan for Product id ${data.productId}`}

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.tsx
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.tsx
@@ -10,8 +10,27 @@ import {
   render,
   useData,
   useContainer,
+  useLocale,
   useSessionToken,
 } from '@shopify/argo-admin-react';
+
+interface Translations {
+  [key: string]: string;
+}
+
+const translations: {
+  [locale: string]: Translations;
+} = {
+  de: {
+    hello: 'Guten Tag',
+  },
+  en: {
+    hello: 'Hello',
+  },
+  fr: {
+    hello: 'Bonjour',
+  },
+};
 
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 // [Shopify admin renders this mode inside a modal container]
@@ -24,6 +43,14 @@ function Add() {
   const {close, done, setPrimaryAction, setSecondaryAction} = useContainer<
     ExtensionPoint.SubscriptionManagementAdd
   >();
+
+  // Information about the merchant's selected language. Use this to support multiple languages.
+  const locale = useLocale();
+
+  // Use locale to set translations with a fallback
+  const localizedStrings: Translations = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
 
   // Session token contains information about the current user. Use it to authenticate calls
   // from your extension to your app server.
@@ -61,6 +88,7 @@ function Add() {
 
   return (
     <>
+      <Text size="titleLarge">{localizedStrings.hello}!</Text>
       <Text>
         Add {`{Product id ${data.productId}}`} to an existing plan or existing
         plans
@@ -92,6 +120,12 @@ function Create() {
   const {close, done} = useContainer<
     ExtensionPoint.SubscriptionManagementCreate
   >();
+
+  const locale = useLocale();
+  const localizedStrings: Translations = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   // Mock plan settings
@@ -123,7 +157,9 @@ function Create() {
   return (
     <Stack distribution="center">
       <Stack vertical>
-        <Text size="titleLarge">Create subscription plan</Text>
+        <Text size="titleLarge">
+          {localizedStrings.hello}! Create subscription plan
+        </Text>
 
         <Card
           title={`Create subscription plan for Product id ${data.productId}`}
@@ -167,6 +203,11 @@ function Remove() {
   const {close, done, setPrimaryAction, setSecondaryAction} = useContainer<
     ExtensionPoint.SubscriptionManagementRemove
   >();
+  const locale = useLocale();
+  const localizedStrings: Translations = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   useEffect(() => {
@@ -189,10 +230,13 @@ function Remove() {
   }, [getSessionToken, done, close, setPrimaryAction, setSecondaryAction]);
 
   return (
-    <Text>
-      Remove {`{Product id ${data.productId}}`} from{' '}
-      {`{Plan group id ${data.sellingPlanGroupId}}`}
-    </Text>
+    <>
+      <Text size="titleLarge">{localizedStrings.hello}!</Text>
+      <Text>
+        Remove {`{Product id ${data.productId}}`} from{' '}
+        {`{Plan group id ${data.sellingPlanGroupId}}`}
+      </Text>
+    </>
   );
 }
 
@@ -202,6 +246,11 @@ function Remove() {
 function Edit() {
   const data = useData<ExtensionPoint.SubscriptionManagementEdit>();
   const [planTitle, setPlanTitle] = useState('Current plan');
+  const locale = useLocale();
+  const localizedStrings: Translations = useMemo(() => {
+    return translations[locale] || translations.en;
+  }, [locale]);
+
   const {getSessionToken} = useSessionToken();
 
   const [percentageOff, setPercentageOff] = useState('10');
@@ -234,7 +283,9 @@ function Edit() {
   return (
     <Stack distribution="center">
       <Stack vertical>
-        <Text size="titleLarge">Edit subscription plan</Text>
+        <Text size="titleLarge">
+          {localizedStrings.hello}! Edit subscription plan
+        </Text>
 
         <Card
           title={`Edit subscription plan for Product id ${data.productId}`}

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.js
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.js
@@ -9,12 +9,30 @@ import {
   render,
 } from '@shopify/argo-admin';
 
+const translations = {
+  de: {
+    hello: 'Guten Tag',
+  },
+  en: {
+    hello: 'Hello',
+  },
+  fr: {
+    hello: 'Bonjour',
+  },
+};
+
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 // [Shopify admin renders this mode inside a modal container]
 function Add(root, api) {
   // Information about the product and/or plan your extension is editing.
   // Your extension receives different data in each mode.
   const data = api.data;
+
+  // Information about the merchant's selected language. Use this to support multiple languages.
+  const locale = api.locale.initialValue;
+
+  // Use locale to set translations with a fallback
+  const localizedStrings = translations[locale] || translations.en;
 
   // Session token contains information about the current user. Use it to authenticate calls
   // from your extension to your app server.
@@ -49,6 +67,10 @@ function Add(root, api) {
     onAction: () => close(),
   });
 
+  const localizedHelloText = root.createComponent(Text);
+  localizedHelloText.appendChild(root.createText(`${localizedStrings.hello}!`));
+  root.appendChild(localizedHelloText);
+
   const textElement = root.createComponent(Text);
   textElement.appendChild(
     root.createText(
@@ -82,8 +104,11 @@ function Add(root, api) {
 // [Shopify admin renders this mode inside an app overlay container]
 function Create(root, api) {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done} = api.container;
+
+  const localizedStrings = translations[locale] || translations.en;
 
   const primaryButton = root.createComponent(Button, {
     title: 'Create plan',
@@ -109,7 +134,9 @@ function Create(root, api) {
   containerStack.appendChild(rootStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
-  textElement.appendChild(root.createText('Create subscription plan'));
+  textElement.appendChild(
+    root.createText(`${localizedStrings.hello}! Create subscription plan`)
+  );
   rootStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
@@ -180,8 +207,11 @@ function Create(root, api) {
 // [Shopify admin renders this mode inside a modal container]
 function Remove(root, api) {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+
+  const localizedStrings = translations[locale] || translations.en;
 
   setPrimaryAction({
     content: 'Remove from plan',
@@ -200,6 +230,10 @@ function Remove(root, api) {
     onAction: () => close(),
   });
 
+  const localizedHelloText = root.createComponent(Text);
+  localizedHelloText.appendChild(root.createText(`${localizedStrings.hello}!`));
+  root.appendChild(localizedHelloText);
+
   const textElement = root.createComponent(Text);
   textElement.appendChild(
     root.createText(
@@ -216,8 +250,11 @@ function Remove(root, api) {
 // [Shopify admin renders this mode inside an app overlay container]
 function Edit(root, api) {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done} = api.container;
+
+  const localizedStrings = translations[locale] || translations.en;
 
   const primaryButton = root.createComponent(Button, {
     title: 'Edit plan',
@@ -243,7 +280,9 @@ function Edit(root, api) {
   containerStack.appendChild(rootStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
-  textElement.appendChild(root.createText('Edit subscription plan'));
+  textElement.appendChild(
+    root.createText(`${localizedStrings.hello}! Edit subscription plan`)
+  );
   rootStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.ts
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.ts
@@ -10,6 +10,24 @@ import {
   Checkbox,
 } from '@shopify/argo-admin';
 
+interface Translations {
+  [key: string]: string;
+}
+
+const translations: {
+  [locale: string]: Translations;
+} = {
+  de: {
+    hello: 'Guten Tag',
+  },
+  en: {
+    hello: 'Hello',
+  },
+  fr: {
+    hello: 'Bonjour',
+  },
+};
+
 // 'Add' mode should allow a user to add the current product to an existing selling plan
 // [Shopify admin renders this mode inside a modal container]
 const Add: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementAdd] = (
@@ -19,6 +37,13 @@ const Add: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementAdd] = (
   // Information about the product and/or plan your extension is editing.
   // Your extension receives different data in each mode.
   const data = api.data;
+
+  // Information about the merchant's selected language. Use this to support multiple languages.
+  const locale = api.locale.initialValue;
+
+  // Use locale to set translations with a fallback
+  const localizedStrings: Translations =
+    translations[locale] || translations.en;
 
   // Session token contains information about the current user. Use it to authenticate calls
   // from your extension to your app server.
@@ -53,6 +78,10 @@ const Add: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementAdd] = (
     content: 'Cancel',
     onAction: () => close(),
   });
+
+  const localizedHelloText = root.createComponent(Text);
+  localizedHelloText.appendChild(root.createText(`${localizedStrings.hello}!`));
+  root.appendChild(localizedHelloText);
 
   const textElement = root.createComponent(Text);
   textElement.appendChild(
@@ -90,8 +119,12 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
   api
 ) => {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done} = api.container;
+
+  const localizedStrings: Translations =
+    translations[locale] || translations.en;
 
   const primaryButton = root.createComponent(Button, {
     title: 'Create plan',
@@ -117,7 +150,9 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
   containerStack.appendChild(rootStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
-  textElement.appendChild(root.createText('Create subscription plan'));
+  textElement.appendChild(
+    root.createText(`${localizedStrings.hello}! Create subscription plan`)
+  );
   rootStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
@@ -191,8 +226,12 @@ const Remove: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementRemove
   api
 ) => {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done, setPrimaryAction, setSecondaryAction} = api.container;
+
+  const localizedStrings: Translations =
+    translations[locale] || translations.en;
 
   setPrimaryAction({
     content: 'Remove plan',
@@ -210,6 +249,10 @@ const Remove: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementRemove
     content: 'Cancel',
     onAction: () => close(),
   });
+
+  const localizedHelloText = root.createComponent(Text);
+  localizedHelloText.appendChild(root.createText(`${localizedStrings.hello}!`));
+  root.appendChild(localizedHelloText);
 
   const textElement = root.createComponent(Text);
   textElement.appendChild(
@@ -230,8 +273,12 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
   api
 ) => {
   const data = api.data;
+  const locale = api.locale.initialValue;
   const sessionToken = api.sessionToken;
   const {close, done} = api.container;
+
+  const localizedStrings: Translations =
+    translations[locale] || translations.en;
 
   const primaryButton = root.createComponent(Button, {
     title: 'Edit plan',
@@ -257,7 +304,9 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
   containerStack.appendChild(rootStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
-  textElement.appendChild(root.createText('Edit subscription plan'));
+  textElement.appendChild(
+    root.createText(`${localizedStrings.hello}! Edit subscription plan`)
+  );
   rootStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {


### PR DESCRIPTION
Relates to https://github.com/Shopify/app-extension-libs/issues/865

This PR adds examples on how to localize extensions. Translation is handled in the most basic way, as a JSON object, with "hello" in 3 languages, and English as the fallback.

<img width="1476" alt="Screen Shot 2020-09-16 at 2 40 29 PM" src="https://user-images.githubusercontent.com/2709526/93378901-12263f00-f82b-11ea-89fd-17156789485e.png">

## How to 🎩 
1. In a terminal, generate a **Subscription Management** extension from the project root: `yarn; yarn generate --type=SUBSCRIPTION_MANAGEMENT`
1. Start the simulator with `yarn server`
1. Check that the word "Hello" is translated for supported languages (en, fr, de), and falls back to English for everything else
1. Reset this branch and repeat the same test for other templates