### PR TITLE
chore: upgrade-argo-admin-0.4.4

### DIFF
--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.js
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.js
@@ -7,6 +7,7 @@ import {
   TextField,
   Text,
   Stack,
+  extend,
   render,
   useData,
   useContainer,
@@ -134,9 +135,9 @@ function Create() {
   const actions = useMemo(
     () => (
       <Stack distribution="fill">
-        <Button title="Cancel" onClick={() => close()} />
+        <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
-          <Button title="Create plan" onClick={onPrimaryAction} primary />
+          <Button title="Create plan" onPress={onPrimaryAction} primary />
         </Stack>
       </Stack>
     ),
@@ -256,9 +257,9 @@ function Edit() {
   const actions = useMemo(
     () => (
       <Stack distribution="fill">
-        <Button title="Cancel" onClick={() => close()} />
+        <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
-          <Button title="Edit plan" onClick={onPrimaryAction} primary />
+          <Button title="Edit plan" onPress={onPrimaryAction} primary />
         </Stack>
       </Stack>
     ),
@@ -307,7 +308,19 @@ function Edit() {
 }
 
 // Your extension must render all four modes
-render(ExtensionPoint.SubscriptionManagementAdd, () => <Add />);
-render(ExtensionPoint.SubscriptionManagementCreate, () => <Create />);
-render(ExtensionPoint.SubscriptionManagementRemove, () => <Remove />);
-render(ExtensionPoint.SubscriptionManagementEdit, () => <Edit />);
+extend(
+  ExtensionPoint.SubscriptionManagementAdd,
+  render(() => <Add />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementCreate,
+  render(() => <Create />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementRemove,
+  render(() => <Remove />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementEdit,
+  render(() => <Edit />)
+);

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.tsx
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/react.template.tsx
@@ -7,6 +7,7 @@ import {
   TextField,
   Text,
   Stack,
+  extend,
   render,
   useData,
   useContainer,
@@ -145,9 +146,9 @@ function Create() {
   const actions = useMemo(
     () => (
       <Stack distribution="fill">
-        <Button title="Cancel" onClick={() => close()} />
+        <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
-          <Button title="Create plan" onClick={onPrimaryAction} primary />
+          <Button title="Create plan" onPress={onPrimaryAction} primary />
         </Stack>
       </Stack>
     ),
@@ -271,9 +272,9 @@ function Edit() {
   const actions = useMemo(
     () => (
       <Stack distribution="fill">
-        <Button title="Cancel" onClick={() => close()} />
+        <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
-          <Button title="Edit plan" onClick={onPrimaryAction} primary />
+          <Button title="Edit plan" onPress={onPrimaryAction} primary />
         </Stack>
       </Stack>
     ),
@@ -322,7 +323,19 @@ function Edit() {
 }
 
 // Your extension must render all four modes
-render(ExtensionPoint.SubscriptionManagementAdd, () => <Add />);
-render(ExtensionPoint.SubscriptionManagementCreate, () => <Create />);
-render(ExtensionPoint.SubscriptionManagementRemove, () => <Remove />);
-render(ExtensionPoint.SubscriptionManagementEdit, () => <Edit />);
+extend(
+  ExtensionPoint.SubscriptionManagementAdd,
+  render(() => <Add />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementCreate,
+  render(() => <Create />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementRemove,
+  render(() => <Remove />)
+);
+extend(
+  ExtensionPoint.SubscriptionManagementEdit,
+  render(() => <Edit />)
+);

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.js
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.js
@@ -6,7 +6,7 @@ import {
   Button,
   Card,
   Checkbox,
-  render,
+  extend,
 } from '@shopify/argo-admin';
 
 const translations = {
@@ -113,7 +113,7 @@ function Create(root, api) {
   const primaryButton = root.createComponent(Button, {
     title: 'Create plan',
     primary: true,
-    onClick: async () => {
+    onPress: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to create the new plan.
@@ -124,7 +124,7 @@ function Create(root, api) {
   });
   const secondaryButton = root.createComponent(Button, {
     title: 'Cancel',
-    onClick: () => close(),
+    onPress: () => close(),
   });
 
   const containerStack = root.createComponent(Stack, {distribution: 'center'});
@@ -259,7 +259,7 @@ function Edit(root, api) {
   const primaryButton = root.createComponent(Button, {
     title: 'Edit plan',
     primary: true,
-    onClick: async () => {
+    onPress: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to modify the selling plan.
@@ -270,7 +270,7 @@ function Edit(root, api) {
   });
   const secondaryButton = root.createComponent(Button, {
     title: 'Cancel',
-    onClick: () => close(),
+    onPress: () => close(),
   });
 
   const containerStack = root.createComponent(Stack, {distribution: 'center'});
@@ -349,7 +349,7 @@ function Edit(root, api) {
 }
 
 // Your extension must render all four modes
-render(ExtensionPoint.SubscriptionManagementAdd, Add);
-render(ExtensionPoint.SubscriptionManagementCreate, Create);
-render(ExtensionPoint.SubscriptionManagementRemove, Remove);
-render(ExtensionPoint.SubscriptionManagementEdit, Edit);
+extend(ExtensionPoint.SubscriptionManagementAdd, Add);
+extend(ExtensionPoint.SubscriptionManagementCreate, Create);
+extend(ExtensionPoint.SubscriptionManagementRemove, Remove);
+extend(ExtensionPoint.SubscriptionManagementEdit, Edit);

--- a/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.ts
+++ b/scripts/generate/templates/SUBSCRIPTION_MANAGEMENT/vanilla.template.ts
@@ -1,7 +1,7 @@
 import {
   ExtensionPoint,
   ExtensionPointCallback,
-  render,
+  extend,
   TextField,
   Text,
   Stack,
@@ -129,7 +129,7 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
   const primaryButton = root.createComponent(Button, {
     title: 'Create plan',
     primary: true,
-    onClick: async () => {
+    onPress: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to create the new plan.
@@ -140,7 +140,7 @@ const Create: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementCreate
   });
   const secondaryButton = root.createComponent(Button, {
     title: 'Cancel',
-    onClick: () => close(),
+    onPress: () => close(),
   });
 
   const containerStack = root.createComponent(Stack, {distribution: 'center'});
@@ -283,7 +283,7 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
   const primaryButton = root.createComponent(Button, {
     title: 'Edit plan',
     primary: true,
-    onClick: async () => {
+    onPress: async () => {
       const token = await sessionToken.getSessionToken();
 
       // Here, send the form data to your app server to modify the selling plan.
@@ -294,7 +294,7 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
   });
   const secondaryButton = root.createComponent(Button, {
     title: 'Cancel',
-    onClick: () => close(),
+    onPress: () => close(),
   });
 
   const containerStack = root.createComponent(Stack, {distribution: 'center'});
@@ -373,7 +373,7 @@ const Edit: ExtensionPointCallback[ExtensionPoint.SubscriptionManagementEdit] = 
 };
 
 // Your extension must render all four modes
-render(ExtensionPoint.SubscriptionManagementAdd, Add);
-render(ExtensionPoint.SubscriptionManagementCreate, Create);
-render(ExtensionPoint.SubscriptionManagementRemove, Remove);
-render(ExtensionPoint.SubscriptionManagementEdit, Edit);
+extend(ExtensionPoint.SubscriptionManagementAdd, Add);
+extend(ExtensionPoint.SubscriptionManagementCreate, Create);
+extend(ExtensionPoint.SubscriptionManagementRemove, Remove);
+extend(ExtensionPoint.SubscriptionManagementEdit, Edit);


### PR DESCRIPTION
Related to: https://github.com/Shopify/argo-admin-cli/pull/19

Tickets:
https://github.com/Shopify/app-extension-libs/issues/790
https://github.com/Shopify/app-extension-libs/issues/791
https://github.com/Shopify/app-extension-libs/issues/793
https://github.com/Shopify/app-extension-libs/issues/794
https://github.com/Shopify/app-extension-libs/issues/830

## 🎩 instructions

1. [Tophat instructions](https://github.com/Shopify/app-extension-libs/wiki/Test-argo-admin-cli-changes#-tophat-instructions) and additionally change `argo-admin` to alpha as well.

    ```diff
    "devDependencies": {
    -    "@shopify/argo-admin-cli": "latest",
    +    "@shopify/argo-admin-cli": "git+https://github.com/Shopify/argo-admin-cli.git#chore/upgrade-argo-admin-0.4.4-test"
    },

    "dependencies": {
    -    "@shopify/argo-admin": "latest",
    -    "@shopify/argo-admin-host": "latest",
    +    "@shopify/argo-admin": "0.4.4-alpha.1",
    +    "@shopify/argo-admin-host": "0.4.4-alpha.1",
    },
    ```

1. Check that the buttons primary and secondary buttons are working (closing the modal)

