### PR TITLE
fix: move `Card` out of `Stack`

### DIFF
--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/react.template.js
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/react.template.js
@@ -133,7 +133,7 @@ function Create() {
 
   const actions = useMemo(
     () => (
-      <Stack distribution="fill">
+      <Stack spacing="none" distribution="fill">
         <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
           <Button title="Create plan" onPress={onPrimaryAction} primary />
@@ -144,43 +144,43 @@ function Create() {
   );
 
   return (
-    <Stack distribution="center">
-      <Stack vertical>
+    <>
+      <Stack spacing="none">
         <Text size="titleLarge">
           {localizedStrings.hello}! Create subscription plan
         </Text>
-
-        <Card
-          title={`Create subscription plan for Product id ${data.productId}`}
-          sectioned
-        >
-          <TextField
-            label="Plan title"
-            value={planTitle}
-            onChange={setPlanTitle}
-          />
-        </Card>
-
-        <Card title="Delivery and discount" sectioned>
-          <Stack>
-            <TextField
-              type="number"
-              label="Delivery frequency (in weeks)"
-              value={deliveryFrequency}
-              onChange={setDeliveryFrequency}
-            />
-            <TextField
-              type="number"
-              label="Percentage off (%)"
-              value={percentageOff}
-              onChange={setPercentageOff}
-            />
-          </Stack>
-        </Card>
-
-        {actions}
       </Stack>
-    </Stack>
+
+      <Card
+        title={`Create subscription plan for Product id ${data.productId}`}
+        sectioned
+      >
+        <TextField
+          label="Plan title"
+          value={planTitle}
+          onChange={setPlanTitle}
+        />
+      </Card>
+
+      <Card title="Delivery and discount" sectioned>
+        <Stack>
+          <TextField
+            type="number"
+            label="Delivery frequency (in weeks)"
+            value={deliveryFrequency}
+            onChange={setDeliveryFrequency}
+          />
+          <TextField
+            type="number"
+            label="Percentage off (%)"
+            value={percentageOff}
+            onChange={setPercentageOff}
+          />
+        </Stack>
+      </Card>
+
+      {actions}
+    </>
   );
 }
 
@@ -255,7 +255,7 @@ function Edit() {
 
   const actions = useMemo(
     () => (
-      <Stack distribution="fill">
+      <Stack spacing="none" distribution="fill">
         <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
           <Button title="Edit plan" onPress={onPrimaryAction} primary />
@@ -266,43 +266,43 @@ function Edit() {
   );
 
   return (
-    <Stack distribution="center">
-      <Stack vertical>
+    <>
+      <Stack spacing="none">
         <Text size="titleLarge">
           {localizedStrings.hello}! Edit subscription plan
         </Text>
-
-        <Card
-          title={`Edit subscription plan for Product id ${data.productId}`}
-          sectioned
-        >
-          <TextField
-            label="Plan title"
-            value={planTitle}
-            onChange={setPlanTitle}
-          />
-        </Card>
-
-        <Card title="Delivery and discount" sectioned>
-          <Stack>
-            <TextField
-              type="number"
-              label="Delivery frequency (in weeks)"
-              value={deliveryFrequency}
-              onChange={setDeliveryFrequency}
-            />
-            <TextField
-              type="number"
-              label="Percentage off (%)"
-              value={percentageOff}
-              onChange={setPercentageOff}
-            />
-          </Stack>
-        </Card>
-
-        {actions}
       </Stack>
-    </Stack>
+
+      <Card
+        title={`Edit subscription plan for Product id ${data.productId}`}
+        sectioned
+      >
+        <TextField
+          label="Plan title"
+          value={planTitle}
+          onChange={setPlanTitle}
+        />
+      </Card>
+
+      <Card title="Delivery and discount" sectioned>
+        <Stack>
+          <TextField
+            type="number"
+            label="Delivery frequency (in weeks)"
+            value={deliveryFrequency}
+            onChange={setDeliveryFrequency}
+          />
+          <TextField
+            type="number"
+            label="Percentage off (%)"
+            value={percentageOff}
+            onChange={setPercentageOff}
+          />
+        </Stack>
+      </Card>
+
+      {actions}
+    </>
   );
 }
 

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/react.template.tsx
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/react.template.tsx
@@ -144,7 +144,7 @@ function Create() {
 
   const actions = useMemo(
     () => (
-      <Stack distribution="fill">
+      <Stack spacing="none" distribution="fill">
         <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
           <Button title="Create plan" onPress={onPrimaryAction} primary />
@@ -155,43 +155,43 @@ function Create() {
   );
 
   return (
-    <Stack distribution="center">
-      <Stack vertical>
+    <>
+      <Stack spacing="none">
         <Text size="titleLarge">
           {localizedStrings.hello}! Create subscription plan
         </Text>
-
-        <Card
-          title={`Create subscription plan for Product id ${data.productId}`}
-          sectioned
-        >
-          <TextField
-            label="Plan title"
-            value={planTitle}
-            onChange={setPlanTitle}
-          />
-        </Card>
-
-        <Card title="Delivery and discount" sectioned>
-          <Stack>
-            <TextField
-              type="number"
-              label="Delivery frequency (in weeks)"
-              value={deliveryFrequency}
-              onChange={setDeliveryFrequency}
-            />
-            <TextField
-              type="number"
-              label="Percentage off (%)"
-              value={percentageOff}
-              onChange={setPercentageOff}
-            />
-          </Stack>
-        </Card>
-
-        {actions}
       </Stack>
-    </Stack>
+
+      <Card
+        title={`Create subscription plan for Product id ${data.productId}`}
+        sectioned
+      >
+        <TextField
+          label="Plan title"
+          value={planTitle}
+          onChange={setPlanTitle}
+        />
+      </Card>
+
+      <Card title="Delivery and discount" sectioned>
+        <Stack>
+          <TextField
+            type="number"
+            label="Delivery frequency (in weeks)"
+            value={deliveryFrequency}
+            onChange={setDeliveryFrequency}
+          />
+          <TextField
+            type="number"
+            label="Percentage off (%)"
+            value={percentageOff}
+            onChange={setPercentageOff}
+          />
+        </Stack>
+      </Card>
+
+      {actions}
+    </>
   );
 }
 
@@ -270,7 +270,7 @@ function Edit() {
 
   const actions = useMemo(
     () => (
-      <Stack distribution="fill">
+      <Stack spacing="none" distribution="fill">
         <Button title="Cancel" onPress={() => close()} />
         <Stack distribution="trailing">
           <Button title="Edit plan" onPress={onPrimaryAction} primary />
@@ -281,43 +281,43 @@ function Edit() {
   );
 
   return (
-    <Stack distribution="center">
-      <Stack vertical>
+    <>
+      <Stack spacing="none">
         <Text size="titleLarge">
           {localizedStrings.hello}! Edit subscription plan
         </Text>
-
-        <Card
-          title={`Edit subscription plan for Product id ${data.productId}`}
-          sectioned
-        >
-          <TextField
-            label="Plan title"
-            value={planTitle}
-            onChange={setPlanTitle}
-          />
-        </Card>
-
-        <Card title="Delivery and discount" sectioned>
-          <Stack>
-            <TextField
-              type="number"
-              label="Delivery frequency (in weeks)"
-              value={deliveryFrequency}
-              onChange={setDeliveryFrequency}
-            />
-            <TextField
-              type="number"
-              label="Percentage off (%)"
-              value={percentageOff}
-              onChange={setPercentageOff}
-            />
-          </Stack>
-        </Card>
-
-        {actions}
       </Stack>
-    </Stack>
+
+      <Card
+        title={`Edit subscription plan for Product id ${data.productId}`}
+        sectioned
+      >
+        <TextField
+          label="Plan title"
+          value={planTitle}
+          onChange={setPlanTitle}
+        />
+      </Card>
+
+      <Card title="Delivery and discount" sectioned>
+        <Stack>
+          <TextField
+            type="number"
+            label="Delivery frequency (in weeks)"
+            value={deliveryFrequency}
+            onChange={setDeliveryFrequency}
+          />
+          <TextField
+            type="number"
+            label="Percentage off (%)"
+            value={percentageOff}
+            onChange={setPercentageOff}
+          />
+        </Stack>
+      </Card>
+
+      {actions}
+    </>
   );
 }
 

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/vanilla.template.js
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/vanilla.template.js
@@ -126,23 +126,20 @@ function Create(root, api) {
     onPress: () => close(),
   });
 
-  const containerStack = root.createComponent(Stack, {distribution: 'center'});
-  root.appendChild(containerStack);
-
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  containerStack.appendChild(rootStack);
+  const textContainerStack = root.createComponent(Stack, {vertical: true});
+  root.appendChild(textContainerStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
   textElement.appendChild(
     root.createText(`${localizedStrings.hello}! Create subscription plan`)
   );
-  rootStack.appendChild(textElement);
+  textContainerStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
     sectioned: true,
     title: `Create subscription plan for Product id ${data.productId}`,
   });
-  rootStack.appendChild(planTitleCard);
+  root.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -159,7 +156,7 @@ function Create(root, api) {
     sectioned: true,
     title: 'Delivery and discount',
   });
-  rootStack.appendChild(planDetailsCard);
+  root.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
   planDetailsCard.appendChild(stack);
@@ -188,8 +185,11 @@ function Create(root, api) {
   });
   stack.appendChild(percentageOffField);
 
-  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
-  rootStack.appendChild(actionsElement);
+  const actionsElement = root.createComponent(Stack, {
+    spacing: 'none',
+    distribution: 'fill',
+  });
+  root.appendChild(actionsElement);
   actionsElement.appendChild(secondaryButton);
 
   const primaryButtonStack = root.createComponent(Stack, {
@@ -272,23 +272,23 @@ function Edit(root, api) {
     onPress: () => close(),
   });
 
-  const containerStack = root.createComponent(Stack, {distribution: 'center'});
-  root.appendChild(containerStack);
-
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  containerStack.appendChild(rootStack);
+  const textContainerStack = root.createComponent(Stack, {
+    spacing: 'none',
+    vertical: true,
+  });
+  root.appendChild(textContainerStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
   textElement.appendChild(
     root.createText(`${localizedStrings.hello}! Edit subscription plan`)
   );
-  rootStack.appendChild(textElement);
+  textContainerStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
     sectioned: true,
     title: `Edit subscription plan for Product id ${data.productId}`,
   });
-  rootStack.appendChild(planTitleCard);
+  root.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -305,7 +305,7 @@ function Edit(root, api) {
     sectioned: true,
     title: 'Delivery and discount',
   });
-  rootStack.appendChild(planDetailsCard);
+  root.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
   planDetailsCard.appendChild(stack);
@@ -335,7 +335,7 @@ function Edit(root, api) {
   stack.appendChild(percentageOffField);
 
   const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
-  rootStack.appendChild(actionsElement);
+  root.appendChild(actionsElement);
   actionsElement.appendChild(secondaryButton);
 
   const primaryButtonStack = root.createComponent(Stack, {

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/vanilla.template.ts
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/vanilla.template.ts
@@ -142,23 +142,22 @@ const Create: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Create']
     onPress: () => close(),
   });
 
-  const containerStack = root.createComponent(Stack, {distribution: 'center'});
-  root.appendChild(containerStack);
-
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  containerStack.appendChild(rootStack);
+  const textContainerStack = root.createComponent(Stack, {
+    spacing: 'none',
+  });
+  root.appendChild(textContainerStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
   textElement.appendChild(
     root.createText(`${localizedStrings.hello}! Create subscription plan`)
   );
-  rootStack.appendChild(textElement);
+  textContainerStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
     sectioned: true,
     title: `Create subscription plan for Product id ${data.productId}`,
   });
-  rootStack.appendChild(planTitleCard);
+  root.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -175,7 +174,7 @@ const Create: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Create']
     sectioned: true,
     title: 'Delivery and discount',
   });
-  rootStack.appendChild(planDetailsCard);
+  root.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
   planDetailsCard.appendChild(stack);
@@ -204,8 +203,11 @@ const Create: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Create']
   });
   stack.appendChild(percentageOffField);
 
-  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
-  rootStack.appendChild(actionsElement);
+  const actionsElement = root.createComponent(Stack, {
+    spacing: 'none',
+    distribution: 'fill',
+  });
+  root.appendChild(actionsElement);
   actionsElement.appendChild(secondaryButton);
 
   const primaryButtonStack = root.createComponent(Stack, {
@@ -296,23 +298,20 @@ const Edit: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Edit'] = (
     onPress: () => close(),
   });
 
-  const containerStack = root.createComponent(Stack, {distribution: 'center'});
-  root.appendChild(containerStack);
-
-  const rootStack = root.createComponent(Stack, {vertical: true});
-  containerStack.appendChild(rootStack);
+  const textContainerStack = root.createComponent(Stack, {spacing: 'none'});
+  root.appendChild(textContainerStack);
 
   const textElement = root.createComponent(Text, {size: 'titleLarge'});
   textElement.appendChild(
     root.createText(`${localizedStrings.hello}! Edit subscription plan`)
   );
-  rootStack.appendChild(textElement);
+  textContainerStack.appendChild(textElement);
 
   const planTitleCard = root.createComponent(Card, {
     sectioned: true,
     title: `Edit subscription plan for Product id ${data.productId}`,
   });
-  rootStack.appendChild(planTitleCard);
+  root.appendChild(planTitleCard);
 
   const planTitleField = root.createComponent(TextField, {
     label: 'Plan title',
@@ -329,7 +328,7 @@ const Edit: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Edit'] = (
     sectioned: true,
     title: 'Delivery and discount',
   });
-  rootStack.appendChild(planDetailsCard);
+  root.appendChild(planDetailsCard);
 
   const stack = root.createComponent(Stack);
   planDetailsCard.appendChild(stack);
@@ -358,8 +357,11 @@ const Edit: ExtensionPointCallback['Admin::Product::SubscriptionPlan::Edit'] = (
   });
   stack.appendChild(percentageOffField);
 
-  const actionsElement = root.createComponent(Stack, {distribution: 'fill'});
-  rootStack.appendChild(actionsElement);
+  const actionsElement = root.createComponent(Stack, {
+    spacing: 'none',
+    distribution: 'fill',
+  });
+  root.appendChild(actionsElement);
   actionsElement.appendChild(secondaryButton);
 
   const primaryButtonStack = root.createComponent(Stack, {


### PR DESCRIPTION
For https://github.com/Shopify/app-extension-libs/issues/980

Update the template to:
- Move `Card` outside of any `Stack` components
- Add `spacing="none"` to root level `Stack` components

### How to 🎩 
<img width="1233" alt="Screen Shot 2020-10-15 at 4 47 19 PM" src="https://user-images.githubusercontent.com/2709526/96184256-39ddf500-0f06-11eb-9f88-503f937d08ce.png">
↑ Create and Edit mode should remain unchanged and render without errors for all 4 templates.

#### Setup
Ensure the template is using **Argo Admin Simulator** version `0.1.10` without this step, you will encounter an issue where the space between cards is incorrect.
1. Delete any lock files and your `node_modules` folder
1. Install project dependencies with `yarn install`
1. Verify by running: `./node_modules/.bin/argo-admin-cli --version`, this should return `0.1.10`  

#### Test
1. In a terminal, generate a template with: `yarn generate --type=PRODUCT_SUBSCRIPTION`
1. When prompted, select one of the 4 templates
1. Start the simulator: `yarn server`
1. In a browser, open the simulator: http://localhost:39351/
1. Open extension with `CREATE` and then `EDIT`, and check that the contents still render and work properly

Repeat the test with the remaining templates (JS React, Typescript React, JS, Typescript)