### PR TITLE
fix: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 .DS_Store
+.env


### PR DESCRIPTION
The CLI adds a `.env` file, and it should be ignored by git.

Closes #81.