### PR TITLE
Fix eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "devDependencies": {
     "@shopify/argo-admin-cli": "latest",
-    "@shopify/eslint-plugin": "^37.0.1",
+    "@shopify/eslint-plugin": "^39.0.3",
     "@types/yargs": "^15.0.4",
     "eslint": "^7.7.0",
     "inquirer": "^7.1.0",


### PR DESCRIPTION
Fix for Shopify CLI and npm (yarn resolves this for whatever reason).

## Shopify CLI

``` sh
$ shopify create extension --type=PRODUCT_SUBSCRIPTION --name=product_subscription
┏━━ Cloning https://github.com/Shopify/argo-admin-template.git into product_subscription... ━━━━━━━━━━━━━━━━━━━━━━━
┃                                                                                                              100%
┗━━ ✓ Cloned into product_subscription ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.9s) ━━
┏━━ Installing dependencies with npm... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ✗ Unable to install all 12 dependencies
┃ npm ERR! code ERESOLVE
┃ npm ERR! ERESOLVE unable to resolve dependency tree
┃ npm ERR!
┃ npm ERR! While resolving: shopify-app-extension-template@0.1.0
┃ npm ERR! Found: eslint@7.13.0
┃ npm ERR! node_modules/eslint
┃ npm ERR!   dev eslint@"^7.7.0" from the root project
┃ npm ERR!
┃ npm ERR! Could not resolve dependency:
┃ npm ERR! peer eslint@"^6.0.0" from @shopify/eslint-plugin@37.0.1
┃ npm ERR! node_modules/@shopify/eslint-plugin
┃ npm ERR!   dev @shopify/eslint-plugin@"^37.0.1" from the root project
┃ npm ERR!
┃ npm ERR! Fix the upstream dependency conflict, or retry
┃ npm ERR! this command with --force, or --legacy-peer-deps
┃ npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
┃ npm ERR!
┃ npm ERR! See ~/.npm/eresolve-report.txt for a full report.
┃
┃ npm ERR! A complete log of this run can be found in:
┃ npm ERR!     ~/.npm/_logs/2020-11-09T00_04_23_288Z-debug.log
┗━━ An error occurred while installing dependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1.24s) ━━
⭑ Fix the errors and run shopify create extension again.
```

## NPM

``` sh
$ git clone https://github.com/Shopify/argo-admin-template.git
$ cd argo-admin-template
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: shopify-app-extension-template@0.1.0
npm ERR! Found: eslint@7.13.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^7.7.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^6.0.0" from @shopify/eslint-plugin@37.0.1
npm ERR! node_modules/@shopify/eslint-plugin
npm ERR!   dev @shopify/eslint-plugin@"^37.0.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See ~/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2020-11-08T23_59_39_425Z-debug.log
```