### PR TITLE
chore: specify node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shopify-app-extension-template",
   "version": "0.1.0",
   "main": "extension.ts",
+  "engines" : { "node" : ">=10.16.0" },
   "repository": "https://github.com/Shopify/shopify-app-extension-template.git",
   "author": "Shopify <app-extensions@shopify.com>",
   "license": "MIT",


### PR DESCRIPTION
### What problem is this PR solving?

Addresses issue #87. It was actually solved with [an eslint upgrade](https://github.com/Shopify/argo-admin-template/pull/83), but we might as well list the supported node versions to be consistent and avoid future problems. 

### What is the impact of this PR?

This PR should have no impact on the `generate` command within this repo, but specifying the supported node version should provide better feedback when using the Shopify CLI. 
 