### PR TITLE
chore: pass apiKey, title and resource id when serving script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Shopify <app-extensions@shopify.com>",
   "license": "MIT",
   "devDependencies": {
-    "@shopify/argo-admin-cli": "latest",
+    "@shopify/argo-admin-cli": "0.8.3-alpha.0",
     "@shopify/eslint-plugin": "^39.0.3",
     "@types/yargs": "^15.0.4",
     "eslint": "^7.7.0",
@@ -26,6 +26,7 @@
   "dependencies": {
     "@shopify/argo-admin": "latest",
     "@shopify/argo-admin-react": "latest",
+    "dotenv": "^8.2.0",
     "react": "^16.13.0"
   }
 }

--- a/scripts/generate/update-package-json.ts
+++ b/scripts/generate/update-package-json.ts
@@ -2,11 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import {promisify} from 'util';
 
+import * as DotEnv from 'dotenv';
+
 import {Template} from './generate-src';
 
 export function addScripts({entry, type}: {entry: string; type: string}) {
+  DotEnv.config({path: path.resolve('.env')});
+
   return updatePackage((npmPackage) => {
-    npmPackage.scripts.server = `argo-admin-cli server --entry="${entry}" --port=39351 --type=${type}`;
+    npmPackage.scripts.server = `argo-admin-cli server --entry="${entry}" --port=39351 --type=${type} --apiKey=${process.env.SHOPIFY_API_KEY} --title=${process.env.EXTENSION_TITLE}`;
     npmPackage.scripts.build = `argo-admin-cli build --entry="${entry}"`;
     return npmPackage;
   });


### PR DESCRIPTION
Related to https://github.com/Shopify/argo-admin-private/issues/1263

1. In the **argo-admin-template** , run `yarn install`
2. In the **argo-admin-template** , create an `.env` with the following content:
```
SHOPIFY_API_KEY=argo_api_key
EXTENSION_TITLE=MyTestExtension
```
3. In the **argo-admin** repo, run `dev up && dev clean && yarn && dev build-consumer argo-admin-template argo-admin-cli`
4. In the **argo-admin-template** repo, run `chmod 1777 node_modules/.bin/argo-admin-cli`
5. In the **argo-admin-template** repo, run `yarn generate --type=PRODUCT_SUBSCRIPTION` and select any template
6. In the **argo-admin-template** repo, run `yarn server`
7. Verify that the Simulator is working with the sample extension
8. Verify that http://localhost:39351/data serves the manifest JSON