### PR TITLE
Update readme templates and generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,25 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 ## Getting started
 
-Before you start, please [make sure you have `npm` installed](https://www.npmjs.com/get-npm) on your machine.
+Clone this repo
 
- 1. Clone this repo
+```sh
+git clone --depth=1 git@github.com:Shopify/argo-admin-template.git YOUR_EXTENSION_NAME
+```
 
-   ```sh
-   git clone --depth=1 git@github.com:Shopify/argo-admin-template.git YOUR_EXTENSION_NAME
-   ```
+Generate starter code
 
- 2. Generate starter code
+```sh
+cd YOUR_EXTENSION_NAME
 
-   ```sh
-   cd YOUR_EXTENSION_NAME
-   npm install
-   npm run generate -- --type=PRODUCT_SUBSCRIPTION
-   ```
+# With npm
+npm install
+npm run generate -- --type=PRODUCT_SUBSCRIPTION
+
+# With yarn
+yarn
+yarn generate --type=PRODUCT_SUBSCRIPTION
+```
 
 _**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported extension type._
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ yarn generate --type=PRODUCT_SUBSCRIPTION
 
 _**Note:** Currently `PRODUCT_SUBSCRIPTION` and `DEFAULT` are the only supported extension types._
 
-And, finally, see the reasult of the `generate` command:
+Finally, inspect the reasult of the `generate` command:
 
 ```sh
 git diff

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 [Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
 
-**Note:** We do _not_ recommend developers to clone this repo directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
+**Note:** We do _not_ recommend app developers to clone this repo directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
 
 ## Updating this repo
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Before you start, please [make sure you have `npm` installed](https://www.npmjs.
    ```sh
    cd YOUR_EXTENSION_NAME
    npm install
-   npm generate --type=PRODUCT_SUBSCRIPTION
+   npm run generate -- --type=PRODUCT_SUBSCRIPTION
    ```
 
-_**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported type._
+_**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported extension type._
 
 
 ## What's next?

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 [Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
 
-**Note:** There is no need for you to clone this repo directly.
-The CLI will take care of cloning the repo and generating all required files.
+**Note:** We recommend [using the Shopify App CLI to create your Argo-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
+
+If you clone this repo directly and follow the instructions below, you’ll need to set up the Shopify App CLI manually to use your extension.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 [Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
 
-**Note:** This repo is publicly available, but we do not recommended developers to clone it directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
+**Note:** We do _not_ recommended developers to clone this repo directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
 
 ## Updating this repo
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
 # Shopify Admin, app extensions - Starter code
 
 This repo contains starter code for apps that use _Argo_ to extend the UI of the _Shopify Admin_.       
+
 For more about _Argo_ and admin extensions, please [read our docs](https://shopify.dev/tutorials/product-subscription-extension-overview).
 
 ## Getting started
 
-Clone this repo
+[Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
+
+**Note:** There is no need for you to clone this repo directly.
+The CLI will take care of cloning the repo and generating all required files.
+
+## Contributing
+
+Developers working on this repo will find most of the relevant code in the [`scripts/generate`](/scripts/generate).
+
+Start by cloning this repo:
 
 ```sh
-git clone --depth=1 git@github.com:Shopify/argo-admin-template.git YOUR_EXTENSION_NAME
+git clone git@github.com:Shopify/argo-admin-template.git YOUR_EXTENSION_NAME
 ```
 
-Generate starter code
+Then, generate the starter code:
 
 ```sh
 cd YOUR_EXTENSION_NAME
@@ -25,8 +35,10 @@ yarn
 yarn generate --type=PRODUCT_SUBSCRIPTION
 ```
 
-_**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported extension type._
+_**Note:** Currently `PRODUCT_SUBSCRIPTION` and `DEFAULT` are the only supported extension types._
 
-## What's next?
+And, finally, see the reasult of the `generate` command:
 
-The `generate` command has created new files at the root of this repo. Check out the new `README.md` for further instructions, and `index.js/ts/tsx` for starter code.
+```sh
+git diff
+```

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ _**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported extension type
 
 ## What's next?
 
-Check out the generated readme and index files (at the root of this repo), they contain further instructions and code to get you started.
+The `generate` command has created new files at the root of this repo. Check out the new `README.md` for further instructions, and `index.js/ts/tsx` for starter code.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,11 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 [Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
 
-**Note:** We recommend [using the Shopify App CLI to create your Argo-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
+**Note:** This repo is publicly available, but we do not recommended developers to clone it directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
 
-If you clone this repo directly and follow the instructions below, you’ll need to set up the Shopify App CLI manually to use your extension.
+## Updating this repo
 
-## Contributing
-
-Developers working on this repo will find most of the relevant code in the [`scripts/generate`](/scripts/generate).
+Shopify developers working on this repo will find most of the relevant code in the [`scripts/generate`](/scripts/generate).
 
 Start by cloning this repo:
 
@@ -38,7 +36,7 @@ yarn generate --type=PRODUCT_SUBSCRIPTION
 
 _**Note:** Currently `PRODUCT_SUBSCRIPTION` and `DEFAULT` are the only supported extension types._
 
-Finally, inspect the reasult of the `generate` command:
+Finally, inspect the result of the `generate` command:
 
 ```sh
 git diff

--- a/README.md
+++ b/README.md
@@ -1,49 +1,29 @@
-# Setup
+# Shopify Admin, app extensions - Starter code
 
-## CLI
-If you have grabbed this template from the Shopify CLI you should be good to go!
+This repo contains starter code for apps that use _Argo_ to extend the UI of the _Shopify Admin_.       
+For more about _Argo_ and admin extensions, please [read our docs](https://shopify.dev/tutorials/product-subscription-extension-overview).
 
-Start developing your awesome extension.
+## Getting started
+
+Before you start, please [make sure you have `npm` installed](https://www.npmjs.com/get-npm) on your machine.
+
+ 1. Clone this repo
+
+   ```sh
+   git clone --depth=1 git@github.com:Shopify/argo-admin-template.git YOUR_EXTENSION_NAME
+   ```
+
+ 2. Generate starter code
+
+   ```sh
+   cd YOUR_EXTENSION_NAME
+   npm install
+   npm generate --type=PRODUCT_SUBSCRIPTION
+   ```
+
+_**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported type._
 
 
-## From github
-If you grabbed this template directly from github:
+## What's next?
 
-#### npm
-```bash
-## With npm
-npm install
-
-npm run generate -- --type=PRODUCT_SUBSCRIPTION
-
-## With yarn
-yarn
-
-yarn generate --type=PRODUCT_SUBSCRIPTION --template=javascript-react
-```
-
-### Available extensions:
-  - PRODUCT_SUBSCRIPTION
-
-**Note:**
-Once you're setup, you may delete the `scripts` folder as you will no longer need it.
-
-Documentation on all of the components and utilities in the `argo-admin` library can be found in the [docs folder](./docs).
-
-### Local development
-
-During the setup, a new script has been added to your `package.json` for local development. Run the command to start developing locally. See [Local development with argo-admin-cli](https://www.npmjs.com/package/@shopify/argo-admin-cli#local-development).
-
-```bash
-  npm run server
-```
-
-Your starting file is the index file in the root folder (`index.js`, `index.ts`, or `index.tsx`).
-
-### Build
-
-During the setup, a new script has been added to your `package.json` for building your code. Run the command to start developing locally. See [Build with argo-admin-cli](https://www.npmjs.com/package/@shopify/argo-admin-cli#build).
-
-```bash
-  npm run build
-```
+Check out the generated readme and index files (at the root of this repo), they contain further instructions and code to get you started.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more about _Argo_ and admin extensions, please [read our docs](https://shopi
 
 [Use the Shopify App CLI to create your _Argo_-enabled extension](https://shopify.dev/tutorials/getting-started-product-subscription-extension#scaffold-a-product-subscription-app-extension).
 
-**Note:** We do _not_ recommended developers to clone this repo directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
+**Note:** We do _not_ recommend developers to clone this repo directly. If you choose to do so, you will need to follow the instructions below to generate the starter code, and then set up the Shopify App CLI manually to use your extension.
 
 ## Updating this repo
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ yarn generate --type=PRODUCT_SUBSCRIPTION
 
 _**Note:** Currently `PRODUCT_SUBSCRIPTION` is the only supported extension type._
 
-
 ## What's next?
 
 Check out the generated readme and index files (at the root of this repo), they contain further instructions and code to get you started.

--- a/scripts/generate/generate-src.ts
+++ b/scripts/generate/generate-src.ts
@@ -55,6 +55,8 @@ export async function generateSrc({
     : await getTemplateIdentifier();
   console.log('✅ You selected:', template);
 
+  generate_readme({extensionType, rootDir})
+
   const indexPath = indexPaths[template] || indexPaths[Template.Javascript];
   const ext = path.extname(indexPath);
 
@@ -91,4 +93,16 @@ function isTemplate(
     }
   }
   return false;
+}
+
+function generate_readme({extensionType, rootDir}: {extensionType: string; rootDir: string;}) {
+  const src = `${__dirname}/templates/${extensionType}/README.template.md`;
+  const dst = path.resolve(rootDir, `README.md`)
+  try {
+    fs.writeFileSync(dst, fs.readFileSync(src).toString());
+  } catch (error) {
+    const errorMessage = `README.md file could not be created`;
+    console.error(`${errorMessage}: `, error);
+    throw new Error(errorMessage);
+  }
 }

--- a/scripts/generate/generate-src.ts
+++ b/scripts/generate/generate-src.ts
@@ -55,7 +55,7 @@ export async function generateSrc({
     : await getTemplateIdentifier();
   console.log('✅ You selected:', template);
 
-  generate_readme({extensionType, rootDir})
+  generateReadme({extensionType, rootDir});
 
   const indexPath = indexPaths[template] || indexPaths[Template.Javascript];
   const ext = path.extname(indexPath);
@@ -95,9 +95,15 @@ function isTemplate(
   return false;
 }
 
-function generate_readme({extensionType, rootDir}: {extensionType: string; rootDir: string;}) {
+function generateReadme({
+  extensionType,
+  rootDir,
+}: {
+  extensionType: string;
+  rootDir: string;
+}) {
   const src = `${__dirname}/templates/${extensionType}/README.template.md`;
-  const dst = path.resolve(rootDir, `README.md`)
+  const dst = path.resolve(rootDir, `README.md`);
   try {
     fs.writeFileSync(dst, fs.readFileSync(src).toString());
   } catch (error) {

--- a/scripts/generate/templates/DEFAULT/README.template.md
+++ b/scripts/generate/templates/DEFAULT/README.template.md
@@ -1,0 +1,3 @@
+# Shopify Admin, app extensions
+
+[Read more about _Argo_ and Shopify Admin app extensions](https://shopify.dev/tutorials/argo-extension-authentication).

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
@@ -10,7 +10,11 @@ For more info, [read the docs](https://shopify.dev/tutorials/product-subscriptio
 Run a local server:
 
 ```bash
-  npm run server
+# With npm
+npm run server
+
+# With yarn
+yarn server
 ```
 
 Your starting file is the index file in the root folder (either `index.js`, `index.ts`, or `index.tsx`).
@@ -20,5 +24,9 @@ Your starting file is the index file in the root folder (either `index.js`, `ind
 Build a single minified JavaScript file containing your extension code:
 
 ```bash
-  npm run build
+# With npm
+npm run build
+
+# With yarn
+yarn build
 ```

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
@@ -1,0 +1,23 @@
+# Production Subscription app extension
+
+Product subscription app extensions render UI that allows merchants to manage subscriptions as part of their normal workflow in the Shopify admin.       
+For more info, [read the docs](https://shopify.dev/tutorials/product-subscription-extension-overview).
+
+
+### Local development
+
+Run a local server:
+
+```bash
+  npm run server
+```
+
+Your starting file is the index file in the root folder (either `index.js`, `index.ts`, or `index.tsx`).
+
+### Build
+
+Build a single minified JavaScript file containing your extension code:
+
+```bash
+  npm run build
+```

--- a/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
+++ b/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md
@@ -1,6 +1,7 @@
 # Production Subscription app extension
 
-Product subscription app extensions render UI that allows merchants to manage subscriptions as part of their normal workflow in the Shopify admin.       
+Product subscription app extensions render UI that allows merchants to manage subscriptions as part of their normal workflow in the Shopify admin.
+
 For more info, [read the docs](https://shopify.dev/tutorials/product-subscription-extension-overview).
 
 


### PR DESCRIPTION
# What?

First step towards https://github.com/Shopify/argo-admin-private/issues/1469 

 1. Update the README to [only include instructions for generating the starter code](https://github.com/Shopify/argo-admin-template/blob/jf/update-readme-generation/README.md)
 2. Add readme-templates for each extension type (e.g. here's [the template for product subscription extensions](https://github.com/Shopify/argo-admin-template/blob/jf/update-readme-generation/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md))
 3. Modify the `generate` script to overwrite `README.md` with the correct readme-template.

In follow-up PR's, we can improve the context of each specific template.       
For example, see the README for [product subscription extensions](https://github.com/Shopify/argo-admin-template/blob/jf/update-readme-generation/scripts/generate/templates/PRODUCT_SUBSCRIPTION/README.template.md), it's not even clear what to do once we run `npm server` (what is this little web app running in localhost? What am I support to do with it?).

# Why?

The current README starts by making a distinction between the case where someone clones the repo and the case where the Shopify CLI clones it for them.

 - If the user cloned the repo directly, then there's no point  in mentioning the CLI
 - If the user used the CLI (I'm assuming the CLI runs `generate`), then there's no point in going into the details of how to manually `generate` the starter code

# Question for reviewers

> I'm assuming the CLI runs `generate`

Is this assumption correct?

# How to 🎩 ?

```sh
cd /tmp
git clone git@github.com:Shopify/argo-admin-template.git my_extension
cd my_extension
git checkout jf/update-readme-generation
npm install
npm run generate -- --type=PRODUCT_SUBSCRIPTION
```

When asked to choose a template, select any option (it doesn't matter which one), and verify that `README.md` contains the expected content:

```sh
cat README.md
# The title of the readme should be `Production Subscription app extension`
```
