### PR TITLE
Update React dependency to ^17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "@shopify/argo-admin": "latest",
     "@shopify/argo-admin-react": "latest",
-    "react": "^16.13.0"
+    "react": "^17.0.0"
   }
 }


### PR DESCRIPTION
The latest version of argo-admin-react requires React version ^17.0.0