### PR TITLE
remove hardcoded port

### DIFF
--- a/scripts/generate/update-package-json.ts
+++ b/scripts/generate/update-package-json.ts
@@ -12,7 +12,7 @@ export function addScripts({
   type: string;
 }) {
   return updatePackage((npmPackage) => {
-    npmPackage.scripts.server = `argo-admin-cli server --entry="${entry}" --port=39351 --type=${type}`;
+    npmPackage.scripts.server = `argo-admin-cli server --entry="${entry}" --type=${type}`;
     npmPackage.scripts.build = `argo-admin-cli build --entry="${entry}"`;
     return npmPackage;
   });


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify-app-cli/issues/1174

As part of the work to pass a tunnel URL (`publicUrl`) to serve command, we also need to pass a port.

This is because if the default port is taken, the tunnel needs to open a port on a different port, so the port needs to be passed to the serve command.

🎩 Tophat instructions.

1. Pull latest from Shopify CLI and change your local branch of Shopify CLI to [`feature/argo-tunnel`](https://github.com/Shopify/shopify-app-cli/pull/1191)
1. Point your local Shopify CLI to this branch by changing this line to:
`clone_progress("clone", "-b", "feature/remove-hardcoded-port", "--single-branch", repository, dest, ctx: ctx)`
1. Run `shopify create extension`
1. Select `Product Subscription`
1. cd into the project and ensure the version of `argo-admin-cli` the extension is using is `0.10.1-alpha.2`
1. Run `shopify serve`

You should see `--port` being passed in once.