### PR TITLE
Lock down version 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Shopify <app-extensions@shopify.com>",
   "license": "MIT",
   "devDependencies": {
-    "@shopify/argo-admin-cli": "latest",
+    "@shopify/argo-admin-cli": "0.9.3",
     "@shopify/eslint-plugin": "^39.0.3",
     "@types/yargs": "^15.0.4",
     "@types/inquirer": "^7.3.1",
@@ -27,8 +27,8 @@
     "lint": "eslint ./scripts --ext .js,.ts,.tsx --format codeframe"
   },
   "dependencies": {
-    "@shopify/argo-admin": "latest",
-    "@shopify/argo-admin-react": "latest",
+    "@shopify/argo-admin": "0.9.3",
+    "@shopify/argo-admin-react": "0.9.3",
     "react": "^16.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "@shopify/argo-admin": "latest",
     "@shopify/argo-admin-react": "latest",
-    "react": "^17.0.0"
+    "react": "^16.13.0"
   }
 }


### PR DESCRIPTION
Lock down to version 0.9.3 until our build tools are compatible with React v17