### PR TITLE
Revert "Lock down version 0.9.3 (#97)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Shopify <app-extensions@shopify.com>",
   "license": "MIT",
   "devDependencies": {
-    "@shopify/argo-admin-cli": "0.9.3",
+    "@shopify/argo-admin-cli": "latest",
     "@shopify/eslint-plugin": "^39.0.3",
     "@types/yargs": "^15.0.4",
     "@types/inquirer": "^7.3.1",
@@ -27,8 +27,8 @@
     "lint": "eslint ./scripts --ext .js,.ts,.tsx --format codeframe"
   },
   "dependencies": {
-    "@shopify/argo-admin": "0.9.3",
-    "@shopify/argo-admin-react": "0.9.3",
-    "react": "^16.13.0"
+    "@shopify/argo-admin": "latest",
+    "@shopify/argo-admin-react": "latest",
+    "react": "^17.0.0"
   }
 }


### PR DESCRIPTION
This reverts commit 110ae386e850f0d984bdbddb8001adcdb5d2d1db.

React v17 turned out not to be an issue at all.